### PR TITLE
feat(url): Add skip_verify param

### DIFF
--- a/url.go
+++ b/url.go
@@ -89,6 +89,18 @@ func ParseURL(str string) (opt ClientOption, err error) {
 		_, addr = parseAddr(addr)
 		opt.InitAddress = append(opt.InitAddress, addr)
 	}
+	if opt.TLSConfig != nil && q.Has("skip_verify") {
+		skipVerifyParam := q.Get("skip_verify")
+		if skipVerifyParam == "" {
+			opt.TLSConfig.InsecureSkipVerify = true
+		} else {
+			skipVerify, err := strconv.ParseBool(skipVerifyParam)
+			if err != nil {
+				return opt, fmt.Errorf("valkey: invalid skip verify: %q", skipVerifyParam)
+			}
+			opt.TLSConfig.InsecureSkipVerify = skipVerify
+		}
+	}
 	opt.AlwaysRESP2 = q.Get("protocol") == "2"
 	opt.DisableCache = q.Get("client_cache") == "0"
 	opt.DisableRetry = q.Get("max_retries") == "0"

--- a/url_test.go
+++ b/url_test.go
@@ -57,6 +57,15 @@ func TestParseURL(t *testing.T) {
 	if opt, err := ParseURL("redis://?write_timeout=a"); !strings.HasPrefix(err.Error(), "valkey: invalid write timeout") {
 		t.Fatalf("unexpected %v %v", opt, err)
 	}
+	if opt, err := ParseURL("rediss://?skip_verify"); err != nil || opt.TLSConfig == nil || !opt.TLSConfig.InsecureSkipVerify {
+		t.Fatalf("unexpected %v %v", opt, err)
+	}
+	if opt, err := ParseURL("rediss://?skip_verify=true"); err != nil || opt.TLSConfig == nil || !opt.TLSConfig.InsecureSkipVerify {
+		t.Fatalf("unexpected %v %v", opt, err)
+	}
+	if opt, err := ParseURL("rediss://?skip_verify=a"); !strings.HasPrefix(err.Error(), "valkey: invalid skip verify") {
+		t.Fatalf("unexpected %v %v", opt, err)
+	}
 	if opt, err := ParseURL("redis://?protocol=2"); !opt.AlwaysRESP2 {
 		t.Fatalf("unexpected %v %v", opt, err)
 	}


### PR DESCRIPTION
Add `skip_verify` or `skip_verify=true` to disable TLS certificate verification. Default is false.

Inspired by various Go drivers:
- ClickHouse: https://github.com/ClickHouse/clickhouse-go/blob/v2.30.0/clickhouse_options.go#L259
- MongoDB: https://github.com/mongodb/mongo-go-driver/blob/v2.0.0/x/mongo/driver/connstring/connstring.go#L609
- MySQL: https://github.com/go-sql-driver/mysql/blob/v1.8.1/dsn.go#L175