### PR TITLE
feat: update commands.json to forbid cross slots

### DIFF
--- a/hack/cmds/commands.json
+++ b/hack/cmds/commands.json
@@ -4778,7 +4778,7 @@
     "arguments": [
       {
         "name": "channel",
-        "type": "string",
+        "type": "key",
         "optional": true,
         "multiple": true
       }

--- a/internal/cmds/gen_pubsub.go
+++ b/internal/cmds/gen_pubsub.go
@@ -169,6 +169,16 @@ func (b Builder) PubsubShardnumsub() (c PubsubShardnumsub) {
 }
 
 func (c PubsubShardnumsub) Channel(channel ...string) PubsubShardnumsubChannel {
+	if c.ks&NoSlot == NoSlot {
+		for _, k := range channel {
+			c.ks = NoSlot | slot(k)
+			break
+		}
+	} else {
+		for _, k := range channel {
+			c.ks = check(c.ks, slot(k))
+		}
+	}
 	c.cs.s = append(c.cs.s, channel...)
 	return (PubsubShardnumsubChannel)(c)
 }
@@ -181,6 +191,16 @@ func (c PubsubShardnumsub) Build() Completed {
 type PubsubShardnumsubChannel Incomplete
 
 func (c PubsubShardnumsubChannel) Channel(channel ...string) PubsubShardnumsubChannel {
+	if c.ks&NoSlot == NoSlot {
+		for _, k := range channel {
+			c.ks = NoSlot | slot(k)
+			break
+		}
+	} else {
+		for _, k := range channel {
+			c.ks = check(c.ks, slot(k))
+		}
+	}
 	c.cs.s = append(c.cs.s, channel...)
 	return c
 }


### PR DESCRIPTION
Update `commands.json` to forbid cross slots in `PUBSUB SHARDNUMSUB`.

related issue: https://github.com/valkey-io/valkey-go/issues/40