### PR TITLE
Ensure deterministic routing in _pickMulti and _pickMultiCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 dist/
 vendor/
+*.swp

--- a/cluster.go
+++ b/cluster.go
@@ -574,7 +574,13 @@ func (c *clusterClient) _pickMulti(multi []Completed) (retries *connretry, init 
 	count := conncountp.Get(len(c.conns), len(c.conns))
 
 	if !init && c.rslots != nil && c.opt.SendToReplicas != nil {
-		destination := make([]conn, len(multi))
+		var destination []conn
+		var stackDestination [32]conn
+		if len(multi) <= len(stackDestination) {
+			destination = stackDestination[:len(multi)]
+		} else {
+			destination = make([]conn, len(multi))
+		}
 		for i, cmd := range multi {
 			var cc conn
 			if c.opt.SendToReplicas(cmd) {
@@ -1029,7 +1035,13 @@ func (c *clusterClient) _pickMultiCache(multi []CacheableTTL) *connretrycache {
 
 		return retries
 	} else {
-		destination := make([]conn, len(multi))
+		var destination []conn
+		var stackDestination [32]conn
+		if len(multi) <= len(stackDestination) {
+			destination = stackDestination[:len(multi)]
+		} else {
+			destination = make([]conn, len(multi))
+		}
 		for i, cmd := range multi {
 			var p conn
 			if c.opt.SendToReplicas(Completed(cmd.Cmd)) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -8147,6 +8147,19 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		}
 	})
 
+	t.Run("DoMulti Multi Slot Large", func(t *testing.T) {
+		var cmds []Completed
+		for i := 0; i < 500; i++ {
+			cmds = append(cmds, client.B().Get().Key("K1{a}").Build())
+		}
+		resps := client.DoMulti(context.Background(), cmds...)
+		for _, resp := range resps {
+			if v, err := resp.ToString(); err != nil || v != "GET K1{a}" {
+				t.Fatalf("unexpected response %v %v", v, err)
+			}
+		}
+	})
+
 	t.Run("DoMultiCache Multi Slot", func(t *testing.T) {
 		c1 := client.B().Get().Key("K1{a}").Cache()
 		c2 := client.B().Get().Key("K2{b}").Cache()
@@ -8156,6 +8169,19 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		}
 		if v, err := resps[1].ToString(); err != nil || v != "GET K2{b}" {
 			t.Fatalf("unexpected response %v %v", v, err)
+		}
+	})
+
+	t.Run("DoMultiCache Multi Slot Large", func(t *testing.T) {
+		var cmds []CacheableTTL
+		for i := 0; i < 500; i++ {
+			cmds = append(cmds, CT(client.B().Get().Key("K1{a}").Cache(), time.Second))
+		}
+		resps := client.DoMultiCache(context.Background(), cmds...)
+		for _, resp := range resps {
+			if v, err := resp.ToString(); err != nil || v != "GET K1{a}" {
+				t.Fatalf("unexpected response %v %v", v, err)
+			}
 		}
 	})
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -8045,3 +8045,117 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		}
 	})
 }
+
+//gocyclo:ignore
+func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+
+	primaryNodeConn := &mockConn{
+		DoMultiFn: func(multi ...Completed) *valkeyresults {
+			resps := make([]ValkeyResult, len(multi))
+			for i, cmd := range multi {
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+			}
+			return &valkeyresults{s: resps}
+		},
+		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
+			resps := make([]ValkeyResult, len(multi))
+			for i, cmd := range multi {
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+			}
+			return &valkeyresults{s: resps}
+		},
+		DoOverride: map[string]func(cmd Completed) ValkeyResult{
+			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
+				return slotsMultiResp
+			},
+			"INFO": func(cmd Completed) ValkeyResult {
+				return newResult(strmsg('+', "INFO"), nil)
+			},
+			"GET K1{a}": func(cmd Completed) ValkeyResult {
+				return newResult(strmsg('+', "GET K1{a}"), nil)
+			},
+			"GET K2{b}": func(cmd Completed) ValkeyResult {
+				return newResult(strmsg('+', "GET K2{b}"), nil)
+			},
+		},
+	}
+	replicaNodeConn := &mockConn{
+		DoMultiFn: func(multi ...Completed) *valkeyresults {
+			resps := make([]ValkeyResult, len(multi))
+			for i, cmd := range multi {
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+			}
+			return &valkeyresults{s: resps}
+		},
+		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
+			resps := make([]ValkeyResult, len(multi))
+			for i, cmd := range multi {
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+			}
+			return &valkeyresults{s: resps}
+		},
+		DoOverride: map[string]func(cmd Completed) ValkeyResult{
+			"GET Do": func(cmd Completed) ValkeyResult {
+				return newResult(strmsg('+', "GET Do"), nil)
+			},
+			"GET K1{a}": func(cmd Completed) ValkeyResult {
+				return newResult(strmsg('+', "GET K1{a}"), nil)
+			},
+			"GET K2{b}": func(cmd Completed) ValkeyResult {
+				return newResult(strmsg('+', "GET K2{b}"), nil)
+			},
+		},
+		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
+			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
+				return newResult(strmsg('+', "GET DoCache"), nil)
+			},
+		},
+	}
+
+	nextNode := -1
+	client, err := newClusterClient(
+		&ClientOption{
+			InitAddress: []string{"127.0.0.1:0"},
+			SendToReplicas: func(cmd Completed) bool {
+				nextNode++
+				return (nextNode/2) % 2 == 0
+			},
+		},
+		func(dst string, opt *ClientOption) conn {
+			if dst == "127.0.0.1:0" || dst == "127.0.2.1:0" { // primary nodes
+				return primaryNodeConn
+			} else { // replica nodes
+				return replicaNodeConn
+			}
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	t.Run("DoMulti Multi Slot", func(t *testing.T) {
+		c1 := client.B().Get().Key("K1{a}").Build()
+		c2 := client.B().Get().Key("K2{b}").Build()
+		resps := client.DoMulti(context.Background(), c1, c2)
+		if v, err := resps[0].ToString(); err != nil || v != "GET K1{a}" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[1].ToString(); err != nil || v != "GET K2{b}" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+	})
+
+	t.Run("DoMultiCache Multi Slot", func(t *testing.T) {
+		c1 := client.B().Get().Key("K1{a}").Cache()
+		c2 := client.B().Get().Key("K2{b}").Cache()
+		resps := client.DoMultiCache(context.Background(), CT(c1, time.Second), CT(c2, time.Second))
+		if v, err := resps[0].ToString(); err != nil || v != "GET K1{a}" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[1].ToString(); err != nil || v != "GET K2{b}" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+	})
+}


### PR DESCRIPTION
The `_pickMulti `and `_pickMultiCache` functions previously invoked the `SendToReplicas` callback twice for the same batch of commands: once to count commands per connection and a second time to assign them.

If the `SendToReplicas` implementation was non-deterministic (e.g., stateful, like a round-robin counter), this could lead to inconsistent routing decisions between the two loops. This could potentially cause a panic if a nil connection was chosen on the second pass.

This change refactors both functions to call `SendToReplicas` only once per command. The chosen destination connection for each command is stored in a temporary slice, which is then used for dispatching. This guarantees that the routing decision is consistent for the entire `DoMulti` or `DoMultiCache` operation.

A test case with a stateful `SendToReplicas` function has been added to verify the fix and prevent regressions in both code paths.