### PR TITLE
perf: saving SendToReplicas results with a bitmap

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -1,0 +1,31 @@
+package valkey
+
+type bitmap struct {
+	bits [3]uint64 // 24 bytes
+	exts []uint64  // 24 bytes
+}
+
+func (b *bitmap) Init(n int) {
+	if n > 192 {
+		b.exts = make([]uint64, (n-192+63)/64)
+	}
+}
+
+func (b *bitmap) Set(i int) {
+	if i < 192 {
+		b.bits[i/64] |= 1 << (i % 64)
+	} else {
+		b.exts[(i-192)/64] |= 1 << (i % 64)
+	}
+}
+
+func (b *bitmap) Get(i int) bool {
+	if i < 192 {
+		return b.bits[i/64]&(1<<(i%64)) != 0
+	}
+	return b.exts[(i-192)/64]&(1<<(i%64)) != 0
+}
+
+func (b *bitmap) Len() int {
+	return len(b.exts)*64 + 192
+}

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -1,0 +1,25 @@
+package valkey
+
+import "testing"
+
+func TestBitmap(t *testing.T) {
+	var bm bitmap
+	bm.Init(2953)
+	if bm.Len() < 2953 {
+		t.Errorf("bitmap length = %d, expected at least %d", bm.Len(), 2953)
+	}
+	for i := 0; i < bm.Len(); i++ {
+		bm.Set(i)
+		for j := 0; j < bm.Len(); j++ {
+			if j <= i {
+				if !bm.Get(j) {
+					t.Errorf("bitmap[%d] should be set after iteration %d, but is not", j, i)
+				}
+			} else {
+				if bm.Get(j) {
+					t.Errorf("bitmap[%d] should not be set after iteration %d, but is", j, i)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hi @PingXie,

I found that saving `SendToReplicas` results in a bitmap is still slightly better than without indirection. 

For the `sec/op` metric, using a bitmap can introduce 1.5% improvement in the on-stack case. In the on-heap case, it can have 10% improvement. And for the `B/op` and `allocs/op` using a bitmap can have more than 99% improvement.

Benchmark:

```sh
▶ go test -run=^$ -bench=BenchmarkPickMulti -count=50 > before.txt
▶ go test -run=^$ -bench=BenchmarkPickMulti -count=50 > bitmap.txt
▶ benchstat before.txt bitmap.txt

goos: darwin
goarch: arm64
pkg: github.com/valkey-io/valkey-go
cpu: Apple M1 Pro
                          │ before.txt  │         bitmap.txt          │
                          │   sec/op    │   sec/op     vs base        │
PickMulti/small_normal-10   918.6n ± 0%   904.6n ± 0%   -1.53% (n=50)
PickMulti/mediu_normal-10   2.715µ ± 0%   2.430µ ± 0%  -10.48% (n=50)
PickMulti/large_normal-10   9.694µ ± 0%   8.790µ ± 2%   -9.33% (n=50)
geomean                     2.891µ        2.683µ        -7.20%

                          │   before.txt    │              bitmap.txt              │
                          │      B/op       │    B/op     vs base                  │
PickMulti/small_normal-10      0.000 ±  ?     0.000 ± 0%        ~ (p=0.311 n=50)
PickMulti/mediu_normal-10   1183.000 ± 0%     4.000 ±  ?  -99.66% (n=50)
PickMulti/large_normal-10    4988.00 ± 0%     20.50 ±  ?  -99.59% (n=50)
geomean                                   ¹               -97.60%                ¹
¹ summaries must be >0 to compute geomean

                          │  before.txt  │               bitmap.txt                │
                          │  allocs/op   │ allocs/op   vs base                     │
PickMulti/small_normal-10   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=50) ¹
PickMulti/mediu_normal-10   1.000 ± 0%     0.000 ± 0%  -100.00% (n=50)
PickMulti/large_normal-10   1.000 ± 0%     0.000 ± 0%  -100.00% (n=50)
geomean                                ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
(base)
```

```go
func BenchmarkPickMulti(b *testing.B) {
	c := clusterClient{
		cmd:    cmds.NewBuilder(cmds.InitSlot),
		rslots: make([]conn, 16384),
		opt: &ClientOption{
			SendToReplicas: func(cmd Completed) bool {
				return cmd.IsReadOnly()
			},
		},
		conns: map[string]connrole{"1": {}, "2": {}, "3": {}},
	}
	rmuxs := [3]*mux{{}, {}, {}}
	pmuxs := [3]*mux{{}, {}, {}}
	for i := 0; i < 16384; i++ {
		c.rslots[i] = rmuxs[i%3]
		c.pslots[i] = pmuxs[i%3]
	}
	populate := func(commands []Completed) {
		for i := 0; i < len(commands); i++ {
			if i%2 == 0 {
				commands[i] = c.B().Get().Key(strconv.Itoa(i)).Build().Pin()
			} else {
				commands[i] = c.B().Set().Key(strconv.Itoa(i)).Value("").Build().Pin()
			}
		}
	}
	recycle := func(retries *connretry) {
		for _, re := range retries.m {
			retryp.Put(re)
		}
		connretryp.Put(retries)
	}
	sb := make([]Completed, 16)
	mb := make([]Completed, 64)
	lb := make([]Completed, 256)
	populate(sb)
	populate(mb)
	populate(lb)
	b.ResetTimer()
	b.Run("small normal", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			retries, _ := c._pickMulti(sb)
			recycle(retries)
		}
	})
	b.Run("mediu normal", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			retries, _ := c._pickMulti(mb)
			recycle(retries)
		}
	})
	b.Run("large normal", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			retries, _ := c._pickMulti(lb)
			recycle(retries)
		}
	})
}
```

I think I am going to take this approach in the next release. Please let me know if you have any concerns about this.