### PR TITLE
docs: update valkeylock comment

### DIFF
--- a/valkeylock/lock.go
+++ b/valkeylock/lock.go
@@ -24,7 +24,7 @@ type LockerOption struct {
 	ClientOption valkey.ClientOption
 	// KeyValidity is the validity duration of locks and will be extended periodically by the ExtendInterval. The default value is 5s.
 	KeyValidity time.Duration
-	// ExtendInterval is the interval to extend KeyValidity. Default value is 1s.
+	// ExtendInterval is the interval to extend KeyValidity. Default value is 1/2 of KeyValidity.
 	ExtendInterval time.Duration
 	// TryNextAfter is the timeout duration before trying the next valkey key for locks. The default value is 20ms.
 	TryNextAfter time.Duration


### PR DESCRIPTION
Updates comment on default value of ExtendInterval in valkeylock to match the actual default value used.

Might be that the proper solution would be to change the actual default value, but the code there was changed more recently than the comment, so seemed like that was what was intended. Also would cause more breakage for users.

Default value seems to be set only on line 64