### PR TITLE
Fix `valkey.dial` span attributes

### DIFF
--- a/valkeyotel/metrics.go
+++ b/valkeyotel/metrics.go
@@ -240,9 +240,6 @@ func serverAttrs(dst string) trace.SpanStartOption {
 		if port, err := strconv.Atoi(port); err == nil {
 			return trace.WithAttributes(attribute.String("server.address", addr), attribute.Int("server.port", port))
 		}
-
-		return trace.WithAttributes(attribute.String("server.address", addr))
 	}
-
 	return trace.WithAttributes(attribute.String("server.address", dst))
 }

--- a/valkeyotel/metrics.go
+++ b/valkeyotel/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -182,7 +183,7 @@ func newClient(opts ...Option) (*otelclient, error) {
 
 func trackDialing(m dialMetrics, t dialTracer, dialFn func(context.Context, string, *net.Dialer, *tls.Config) (conn net.Conn, err error)) func(context.Context, string, *net.Dialer, *tls.Config) (conn net.Conn, err error) {
 	return func(ctx context.Context, dst string, dialer *net.Dialer, tlsConfig *tls.Config) (conn net.Conn, err error) {
-		ctx, span := t.Start(ctx, "valkey.dial", kind, trace.WithAttributes(dbattr, attribute.String("server.address", dst)), t.tAttrs)
+		ctx, span := t.Start(ctx, "valkey.dial", kind, trace.WithAttributes(dbattr), serverAttrs(dst), t.tAttrs)
 		defer span.End()
 
 		m.attempt.Add(ctx, 1, m.addOpts...)
@@ -232,4 +233,16 @@ func defaultDialFn(ctx context.Context, dst string, dialer *net.Dialer, cfg *tls
 		return td.DialContext(ctx, "tcp", dst)
 	}
 	return dialer.DialContext(ctx, "tcp", dst)
+}
+
+func serverAttrs(dst string) trace.SpanStartOption {
+	if addr, port, err := net.SplitHostPort(dst); err == nil {
+		if port, err := strconv.Atoi(port); err == nil {
+			return trace.WithAttributes(attribute.String("server.address", addr), attribute.Int("server.port", port))
+		}
+
+		return trace.WithAttributes(attribute.String("server.address", addr))
+	}
+
+	return trace.WithAttributes(attribute.String("server.address", dst))
 }

--- a/valkeyotel/trace_test.go
+++ b/valkeyotel/trace_test.go
@@ -376,15 +376,16 @@ func TestNewClientSimple(t *testing.T) {
 		t.Fatal("could not find SET span")
 	}
 	commandSpan := spans[commandSpanIdx]
-	validateSpanHasAttribute(t, commandSpan, "any", "label")
+	validateSpanHasAttribute(t, commandSpan, attribute.String("any", "label"))
 
 	dialSpanIdx := slices.IndexFunc(spans, func(span trace.ReadOnlySpan) bool { return span.Name() == "valkey.dial" })
 	if dialSpanIdx == -1 {
 		t.Fatal("could not find dial span")
 	}
 	dialSpan := spans[dialSpanIdx]
-	validateSpanHasAttribute(t, dialSpan, "server.address", "127.0.0.1:6379")
-	validateSpanHasAttribute(t, dialSpan, "any", "label")
+	validateSpanHasAttribute(t, dialSpan, attribute.String("server.address", "127.0.0.1"))
+	validateSpanHasAttribute(t, dialSpan, attribute.Int("server.port", 6379))
+	validateSpanHasAttribute(t, dialSpan, attribute.String("any", "label"))
 
 	metrics := metricdata.ResourceMetrics{}
 	if err := mxp.Collect(context.Background(), &metrics); err != nil {
@@ -422,7 +423,7 @@ func TestNewClientErrorSpan(t *testing.T) {
 	if span.Name() != "valkey.dial" {
 		t.Fatalf("expected span name 'valkey.dial', got %s", span.Name())
 	}
-	validateSpanHasAttribute(t, span, "any", "label")
+	validateSpanHasAttribute(t, span, attribute.String("any", "label"))
 	events := span.Events()
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
@@ -433,12 +434,12 @@ func TestNewClientErrorSpan(t *testing.T) {
 	}
 }
 
-func validateSpanHasAttribute(t *testing.T, span trace.ReadOnlySpan, key, value string) {
+func validateSpanHasAttribute(t *testing.T, span trace.ReadOnlySpan, expected attribute.KeyValue) {
 	t.Helper()
 	if !slices.ContainsFunc(span.Attributes(), func(attr attribute.KeyValue) bool {
-		return string(attr.Key) == key && attr.Value.AsString() == value
+		return attr == expected
 	}) {
-		t.Fatalf("expected attribute '%s: %s' not found in span attributes", key, value)
+		t.Fatalf("expected attribute '%s: %v' not found in span attributes", expected.Key, expected.Value)
 	}
 }
 


### PR DESCRIPTION
From the [OTel semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/server/) docs:

> # Server
> 
> ## Server Attributes
> 
> These attributes may be used to describe the server in a connection-based network interaction where there is one side that initiates the connection (the client is the side that initiates the connection). This covers all TCP network interactions since TCP is connection-based and one side initiates the connection (an exception is made for peer-to-peer communication over TCP where the "user-facing" surface of the protocol / API doesn't expose a clear notion of client and server). This also covers UDP network interactions where one side initiates the interaction, e.g. QUIC (HTTP/3) and DNS.
> 
> **Attributes:**
> 
> | Key | Stability | Value Type | Description | Example Values |
> | --- | --- | --- | --- | --- |
> | <a id="server-address" href="#server-address">`server.address`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
> | <a id="server-port" href="#server-port">`server.port`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | int | Server port number. [2] | `80`; `8080`; `443` |
> 
> **[1] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
> 
> **[2] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.