### PR TITLE
Set `server.*` attrs in more cases

### DIFF
--- a/valkeyotel/trace.go
+++ b/valkeyotel/trace.go
@@ -315,7 +315,7 @@ func (o *otelclient) Nodes() map[string]valkey.Client {
 			cscHits:         o.cscHits,
 			addOpts:         o.addOpts,
 			recordOpts:      o.recordOpts,
-			sAttrs:          o.sAttrs,
+			sAttrs:          serverAttrs(addr),
 			tAttrs:          o.tAttrs,
 			histogramOption: o.histogramOption,
 			dbStmtFunc:      o.dbStmtFunc,

--- a/valkeyotel/trace_test.go
+++ b/valkeyotel/trace_test.go
@@ -297,13 +297,8 @@ func validateTrace(t *testing.T, exp *tracetest.InMemoryExporter, op string, cod
 	if name := exp.GetSpans().Snapshots()[0].Name(); name != op {
 		t.Fatalf("unexpected span name %v", name)
 	}
-	if operation := exp.GetSpans().Snapshots()[0].Attributes()[1].Value.AsString(); operation != op {
-		t.Fatalf("unexpected span name %v", operation)
-	}
-	customAttr := exp.GetSpans().Snapshots()[0].Attributes()[3]
-	if string(customAttr.Key) != "any" || customAttr.Value.AsString() != "label" {
-		t.Fatalf("unexpected custom attr %v", customAttr)
-	}
+	validateSpanHasAttribute(t, exp.GetSpans().Snapshots()[0], attribute.String("db.operation", op))
+	validateSpanHasAttribute(t, exp.GetSpans().Snapshots()[0], attribute.String("any", "label"))
 	if c := exp.GetSpans().Snapshots()[0].Status().Code; c != code {
 		t.Fatalf("unexpected span status code %v", c)
 	}


### PR DESCRIPTION
From the [OTel semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/server/) docs:

> # Server
> 
> ## Server Attributes
> 
> These attributes may be used to describe the server in a connection-based network interaction where there is one side that initiates the connection (the client is the side that initiates the connection). This covers all TCP network interactions since TCP is connection-based and one side initiates the connection (an exception is made for peer-to-peer communication over TCP where the "user-facing" surface of the protocol / API doesn't expose a clear notion of client and server). This also covers UDP network interactions where one side initiates the interaction, e.g. QUIC (HTTP/3) and DNS.
> 
> **Attributes:**
> 
> | Key | Stability | Value Type | Description | Example Values |
> | --- | --- | --- | --- | --- |
> | <a id="server-address" href="#server-address">`server.address`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
> | <a id="server-port" href="#server-port">`server.port`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | int | Server port number. [2] | `80`; `8080`; `443` |
> 
> **[1] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
> 
> **[2] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.

## Related

- https://github.com/valkey-io/valkey-go/pull/94#issuecomment-3661618076