### PR TITLE
fix: race condition in Lua script SHA-1 loading

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -86,7 +86,6 @@ func newLuaScript(script string, readonly bool, noSha1, retryable bool, opts ...
 type Lua struct {
 	script    string
 	sha1      string
-	sha1Call  call
 	maxp      int
 	sha1Mu    sync.RWMutex
 	readonly  bool
@@ -111,25 +110,19 @@ func (s *Lua) Exec(ctx context.Context, c Client, keys, args []string) (resp Val
 		scriptSha1 = s.sha1
 		s.sha1Mu.RUnlock()
 
-		// If not loaded yet, use singleflight to load it.
 		if scriptSha1 == "" {
-			err := s.sha1Call.Do(ctx, func() error {
+			s.sha1Mu.Lock()
+			if s.sha1 == "" { // the double check
 				result := c.Do(ctx, c.B().ScriptLoad().Script(s.script).Build().ToRetryable())
 				if shaStr, err := result.ToString(); err == nil {
-					s.sha1Mu.Lock()
 					s.sha1 = shaStr
+				} else {
 					s.sha1Mu.Unlock()
-					return nil
+					return newErrResult(result.Error())
 				}
-				return result.Error()
-			})
-			if err != nil {
-				return newErrResult(err)
 			}
-			// Reload scriptSha1 after singleflight completes.
-			s.sha1Mu.RLock()
 			scriptSha1 = s.sha1
-			s.sha1Mu.RUnlock()
+			s.sha1Mu.Unlock()
 		}
 	} else {
 		scriptSha1 = s.sha1

--- a/lua_test.go
+++ b/lua_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -524,6 +525,37 @@ func TestNewLuaScriptWithLoadSha1(t *testing.T) {
 	}
 	if !evalshaInvoked {
 		t.Fatal("EVALSHA should have been called")
+	}
+}
+
+func TestNewLuaScriptWithLoadSha1Error(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+	body := strconv.Itoa(rand.Int())
+
+	k := []string{"1", "2"}
+	a := []string{"3", "4"}
+
+	expectedErr := errors.New("SCRIPT LOAD failed")
+
+	c := &client{
+		BFn: func() Builder {
+			return cmds.NewBuilder(cmds.NoSlot)
+		},
+		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
+			commands := cmd.Commands()
+			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
+				return newErrResult(expectedErr)
+			}
+			t.Fatal("unexpected command")
+			return newResult(strmsg('+', "unexpected"), nil)
+		},
+	}
+
+	script := NewLuaScript(body, WithLoadSHA1(true))
+
+	result := script.Exec(context.Background(), c, k, a)
+	if result.Error() != expectedErr {
+		t.Fatalf("expected error %v, got %v", expectedErr, result.Error())
 	}
 }
 


### PR DESCRIPTION
Add double-check pattern inside the singleflight fn() to prevent duplicate SCRIPT LOAD calls. When the mock/server responds instantly, the sequence could be:
1. G1 and G2 both read s.sha1 == ""
2. G1 executes singleflight, completes, sets s.sha1, clears c.ch
3. G2 calls singleflight.Do(), sees c.ch == nil, executes fn() again

The fix re-checks s.sha1 inside the singleflight to handle this race.