### PR TITLE
Make ReadNodeSelector return only replicas

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -463,9 +463,11 @@ func (c *clusterClient) _pick(slot uint16, toReplica bool) (p conn) {
 		if nodes := c.rslots[slot]; len(nodes) > 0 {
 			rIndex := 0
 			if c.opt.ReadNodeSelector != nil {
-				rIndex = c.opt.ReadNodeSelector(slot, nodes)
-				if rIndex < 0 || rIndex >= len(nodes) {
+				rIndex = c.opt.ReadNodeSelector(slot, nodes[1:])
+				if rIndex < 0 || rIndex >= len(nodes)-1 {
 					rIndex = 0
+				} else {
+					rIndex = rIndex + 1
 				}
 			}
 			p = nodes[rIndex].conn
@@ -620,10 +622,13 @@ func (c *clusterClient) _pickMulti(multi []Completed) (retries *connretry, init 
 					bm.Set(i)
 					rIndex := 0
 					if c.opt.ReadNodeSelector != nil {
-						rIndex = c.opt.ReadNodeSelector(slot, nodes)
-						if rIndex < 0 || rIndex >= len(nodes) {
+						rIndex = c.opt.ReadNodeSelector(slot, nodes[1:])
+						if rIndex < 0 || rIndex >= len(nodes)-1 {
 							rIndex = 0
-						} else if rIndex != 0 { // the default itor[i] is 0
+						} else {
+							rIndex = rIndex + 1
+						}
+						if rIndex != 0 {
 							itor[i] = rIndex
 						}
 					}
@@ -1111,9 +1116,11 @@ func (c *clusterClient) _pickMultiCache(multi []CacheableTTL) *connretrycache {
 				if nodes := c.rslots[slot]; len(nodes) > 0 {
 					rIndex := 0
 					if c.opt.ReadNodeSelector != nil {
-						rIndex = c.opt.ReadNodeSelector(slot, nodes)
-						if rIndex < 0 || rIndex >= len(nodes) {
+						rIndex = c.opt.ReadNodeSelector(slot, nodes[1:])
+						if rIndex < 0 || rIndex >= len(nodes)-1 {
 							rIndex = 0
+						} else {
+							rIndex = rIndex + 1
 						}
 					}
 					p = nodes[rIndex].conn

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -9124,7 +9124,7 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 				return true
 			},
 			ReadNodeSelector: func(slot uint16, nodes []NodeInfo) int {
-				return 0
+				return -1
 			},
 		},
 		func(dst string, opt *ClientOption) conn {
@@ -10175,7 +10175,7 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 				return cmd.IsReadOnly()
 			},
 			ReadNodeSelector: func(slot uint16, nodes []NodeInfo) int {
-				return 1
+				return 0
 			},
 		},
 		func(dst string, opt *ClientOption) conn {
@@ -10826,7 +10826,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_Do(t *testing.T) {
 				return true
 			},
 			ReadNodeSelector: func(_ uint16, _ []NodeInfo) int {
-				return 1
+				return 0
 			},
 		},
 		func(dst string, opt *ClientOption) conn {
@@ -10879,7 +10879,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMulti(t *testing.T) {
 				return true
 			},
 			ReadNodeSelector: func(_ uint16, _ []NodeInfo) int {
-				return 1
+				return 0
 			},
 		},
 		func(dst string, opt *ClientOption) conn {
@@ -10934,7 +10934,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 				return true
 			},
 			ReadNodeSelector: func(_ uint16, _ []NodeInfo) int {
-				return 1
+				return 0
 			},
 		},
 		func(dst string, opt *ClientOption) conn {

--- a/helper.go
+++ b/helper.go
@@ -394,14 +394,14 @@ func (s *Scanner) Err() error {
 }
 
 // PreferReplicaNodeSelector prioritizes reading from any replica using Round-Robin.
-// If no replicas are available, it falls back to the primary.
+// If no replicas are available, it falls back to the primary (by returning -1).
 func PreferReplicaNodeSelector() ReadNodeSelectorFunc {
 	var counter atomic.Uint32
 	return func(_ uint16, nodes []NodeInfo) int {
 		length := uint32(len(nodes))
-		if length > 1 {
+		if length > 0 {
 			c := counter.Add(1)
-			return int(c%(length-1)) + 1
+			return int(c % length)
 		}
 		return -1
 	}
@@ -409,33 +409,27 @@ func PreferReplicaNodeSelector() ReadNodeSelectorFunc {
 
 // AZAffinityNodeSelector prioritizes replicas in the same AZ using Round-Robin.
 func AZAffinityNodeSelector(clientAZ string) ReadNodeSelectorFunc {
-	return newAZSelector(clientAZ, 1)
+	return newAZSelector(clientAZ, 0)
 }
 
 // AZAffinityReplicasAndPrimaryNodeSelector prioritizes:
 // 1. Same-AZ Replicas
-// 2. Same-AZ Primary
-// 3. Any Replica
-// 4. Primary
+// 2. Any Replica
+// 3. Primary (returned as -1 to signal fallback)
 func AZAffinityReplicasAndPrimaryNodeSelector(clientAZ string) ReadNodeSelectorFunc {
 	var counter atomic.Uint32
 	return func(_ uint16, nodes []NodeInfo) int {
 		// Same-AZ Replicas
-		if idx := pickAZ(nodes, clientAZ, 1, &counter); idx != -1 {
+		if idx := pickAZ(nodes, clientAZ, 0, &counter); idx != -1 {
 			return idx
 		}
 
 		length := uint32(len(nodes))
 
-		// Same-AZ Primary
-		if length > 0 && nodes[0].AZ == clientAZ {
-			return 0
-		}
-
 		// Any Replica
-		if length > 1 {
+		if length > 0 {
 			c := counter.Add(1)
-			return int(c%(length-1)) + 1
+			return int(c % length)
 		}
 		return -1
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -1794,17 +1794,6 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 			}
 		})
 
-		t.Run("AZAffinityReplicasAndPrimary Same-AZ Primary", func(t *testing.T) {
-			// Client: A, Primary: A, Replicas: B
-			primAZ, rep1AZ, rep2AZ = "zone-A", "zone-B", "zone-B"
-			client := buildClient(AZAffinityReplicasAndPrimaryNodeSelector("zone-A"), []string{"127.0.0.1:6380", "127.0.0.1:6381"})
-
-			resp := client.Do(context.Background(), client.B().Get().Key("k").Build())
-			if val, _ := resp.ToString(); val != "primary" {
-				t.Fatalf("expected primary, got %v", val)
-			}
-		})
-
 		t.Run("AZAffinityReplicasAndPrimary Remote Replica", func(t *testing.T) {
 			// Client: A, All Nodes: B
 			primAZ, rep1AZ, rep2AZ = "zone-B", "zone-B", "zone-B"
@@ -1913,21 +1902,6 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 			}
 		})
 
-		t.Run("AZAffinityReplicasAndPrimary Same-AZ Primary", func(t *testing.T) {
-			// Client in az-1. Replica 1 is az-1.
-			// Wait, we want to test Priority 2 (Primary).
-			// So let's make all Replicas "remote".
-			primAZ = "az-1"
-			rep1AZ, rep2AZ, rep3AZ = "az-2", "az-3", "az-4"
-
-			client := buildCluster(AZAffinityReplicasAndPrimaryNodeSelector("az-1"))
-
-			// Should prioritize Primary (Same AZ) over Replicas (Different AZ)
-			resp := client.Do(context.Background(), client.B().Get().Key("k").Build())
-			if val, _ := resp.ToString(); val != "primary" {
-				t.Fatalf("expected primary (same AZ), got %v", val)
-			}
-		})
 	})
 
 	t.Run("zero allocation guarantee", func(t *testing.T) {

--- a/standalone.go
+++ b/standalone.go
@@ -77,14 +77,11 @@ func (s *standalone) B() Builder {
 
 func (s *standalone) pick(slot uint16) *singleClient {
 	if s.nodeSelector != nil {
-		rIndex := s.nodeSelector(slot, s.nodes)
-		if rIndex < 0 || rIndex >= len(s.nodes) {
-			rIndex = 0
-		}
-		if rIndex == 0 {
+		rIndex := s.nodeSelector(slot, s.nodes[1:])
+		if rIndex < 0 || rIndex >= len(s.nodes)-1 {
 			return s.primary.Load()
 		}
-		return s.replicas[rIndex-1]
+		return s.replicas[rIndex]
 	}
 
 	if len(s.replicas) == 1 {

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -1035,7 +1035,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 				return cmd.IsReadOnly()
 			},
 			ReadNodeSelector: func(slot uint16, nodes []NodeInfo) int {
-				for i := 1; i < len(nodes); i++ {
+				for i := 0; i < len(nodes); i++ {
 					if nodes[i].AZ == "us-east-1a" {
 						return i
 					}

--- a/valkey.go
+++ b/valkey.go
@@ -141,7 +141,7 @@ type ClientOption struct {
 	// NOTE: This function must be used with the SendToReplicas function.
 	ReplicaSelector ReplicaSelectorFunc
 
-	// ReadNodeSelector returns index of node selected for a read only command.
+	// ReadNodeSelector returns index of replica node selected for a read only command.
 	// If set, ReadNodeSelector is prioritized over ReplicaSelector.
 	// If the returned index is out of range, the primary node will be selected.
 	// The function is called only when SendToReplicas returns true.


### PR DESCRIPTION
Right now we use logic that enables `SendtoReplicas`, which lets you also customize `ReadNodeSelector`. The weird thing is that even though `SendToReplicas` is true, `ReadNodeSelector` still lets you choose a primary.

Just from the understanding. We have two cases:

1. SendToReplicas = false: ReadNodeSelector never triggered, and command sent to the primary node
2. SendToReplicas = true: ReadNodeSelector triggered, and command set to the replica nodes

But the existing code does not do (2). This PR aims to do that to align on what the variable states.

----

**IMPORTANT:** This is a breaking change for people who expected a primary from ReadNodeSelector btw. But they can still get the primary by passing "-1" instead of 0. Or passing a number out of index (lets say 999999)

And to be frank, this should be the right behavior. ReadNodeSelector, given its exclusive to SendToReplicas, should only read replica indexes. So replica 1 should be index 0 and so forth...

Before, lets say you wanted to have a random node read:

```go
// before
cfg.ReadNodeSelector = func(slot uint16, nodes []valkey.NodeInfo) int {
    if len(nodes) <= 1 {
        return 0
    }
    return rand.IntN(len(nodes)-1) + 1 // skip index 0 (assumed primary)
}

// after
cfg.ReadNodeSelector = func(slot uint16, nodes []valkey.NodeInfo) int {
    if len(nodes) == 0 {
        return -1
    }
    return rand.IntN(len(nodes))
}
```

---

https://github.com/redis/rueidis/discussions/688#discussioncomment-11510498