### PR TITLE
Make Pipeliner embed Cmdable

### DIFF
--- a/valkeycompat/pipeline.go
+++ b/valkeycompat/pipeline.go
@@ -50,7 +50,7 @@ import (
 // To avoid this: it is a good idea to use reasonable bigger read/write timeouts
 // depends on your batch size and/or use TxPipeline.
 type Pipeliner interface {
-	CoreCmdable
+	Cmdable
 
 	// Len is to obtain the number of commands in the pipeline that have not yet been executed.
 	Len() int
@@ -67,6 +67,7 @@ type Pipeliner interface {
 }
 
 var _ Pipeliner = (*Pipeline)(nil)
+var _ Cmdable = (*Pipeline)(nil)
 
 type proxyresult struct {
 	err error
@@ -3161,6 +3162,30 @@ func (c *Pipeline) ModuleLoadex(ctx context.Context, conf *ModuleLoadexConfig) *
 	ret := c.comp.ModuleLoadex(ctx, conf)
 	c.rets = append(c.rets, ret)
 	return ret
+}
+
+func (c *Pipeline) Cache(_ time.Duration) CacheCompat {
+	panic("not implemented")
+}
+
+func (c *Pipeline) Subscribe(_ context.Context, _ ...string) PubSub {
+	panic("not implemented")
+}
+
+func (c *Pipeline) PSubscribe(_ context.Context, _ ...string) PubSub {
+	panic("not implemented")
+}
+
+func (c *Pipeline) SSubscribe(_ context.Context, _ ...string) PubSub {
+	panic("not implemented")
+}
+
+func (c *Pipeline) Watch(_ context.Context, _ func(Tx) error, _ ...string) error {
+	panic("not implemented")
+}
+
+func (c *Pipeline) Client() valkey.Client {
+	return c.comp.client.(*proxy).Client
 }
 
 // Len returns the number of queued commands.


### PR DESCRIPTION
Pipeliner in go-redis uses Cmdable, but in valkeycompat, it is CoreCmdable. This following code shows the issue:

```go
// using go-redis
client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
    return helper(ctx, pipe) // ok
})

// using valkeycompat
client.Pipelined(ctx, func(pipe valkeycompat.Pipeliner) error {
    return helper(ctx, pipe) // error: Pipeliner does not implement Cmdable
})
```

This PR will make sure the second code block will not continue to have such error.

----

This was tested by making sure this succeeds on local import of valkey-go.

```go
package main

import (
	"context"
	"fmt"

	"github.com/redis/go-redis/v9"
	"github.com/valkey-io/valkey-go/valkeycompat"
)

func redisHelper(_ context.Context, _ redis.Cmdable) {}

func valkeyHelper(_ context.Context, _ valkeycompat.Cmdable) {}

func main() {
	ctx := context.Background()

	var grPipe redis.Pipeliner = &redis.Pipeline{}
	redisHelper(ctx, grPipe)
	fmt.Println("go-redis works")

	var vkPipe valkeycompat.Pipeliner = &valkeycompat.Pipeline{}
	valkeyHelper(ctx, vkPipe)
	fmt.Println("valkeycompat works")
}

```