### PR TITLE
valkeycompat: Make StringCmd.Bool() match go-redis

### DIFF
--- a/valkeycompat/command.go
+++ b/valkeycompat/command.go
@@ -379,7 +379,10 @@ func (cmd *StringCmd) Bytes() ([]byte, error) {
 }
 
 func (cmd *StringCmd) Bool() (bool, error) {
-	return cmd.val != "", cmd.err
+	if cmd.err != nil {
+		return false, cmd.err
+	}
+	return strconv.ParseBool(cmd.Val())
 }
 
 func (cmd *StringCmd) Int() (int, error) {

--- a/valkeycompat/command_test.go
+++ b/valkeycompat/command_test.go
@@ -1187,6 +1187,49 @@ func TestClientInfoParsing(t *testing.T) {
 	}
 }
 
+func TestStringCmdBool(t *testing.T) {
+	t.Parallel()
+
+	cmdErr := fmt.Errorf("injected")
+	cmd := &StringCmd{}
+	cmd.SetErr(cmdErr)
+	b, err := cmd.Bool()
+	if err != cmdErr || b != false {
+		t.Fatalf("Bool() with SetErr = (%v, %v), want (false, cmdErr)", b, err)
+	}
+
+	tests := []struct {
+		input string
+		want  bool
+		isErr bool
+	}{
+		{"0", false, false},
+		{"1", true, false},
+		{"false", false, false},
+		{"true", true, false},
+		{"", false, true},
+		{"garbage", false, true},
+	}
+	for _, tt := range tests {
+		c := &StringCmd{}
+		c.SetVal(tt.input)
+		got, err := c.Bool()
+		if tt.isErr {
+			if err == nil {
+				t.Errorf("input %q: got (%v, nil), want error", tt.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("input %q: unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("input %q: got %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 // TestCacheHitCmd tests the IsCacheHit and setIsCacheHit functionality for Cmd
 func TestCacheHitCmd(t *testing.T) {
 	cmd := &Cmd{}


### PR DESCRIPTION
(we were migrating some client and noticed this, figure to add it upstream too, thanks!)

Reference (go-redis v9.19.0):
https://github.com/redis/go-redis/blob/v9.19.0/command.go#L1383-L1388