### PR TITLE
Pin dependencies in GitHub Workflows and dockertest.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   validate-modules:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Validate Required Modules
         run: |
           # Find all module directories: valkey* (except valkeylock), om, and mock
@@ -39,7 +39,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - id: set-matrix
         run: |
           echo "matrix=$(find . -maxdepth 2 -type f -name 'go.mod' | xargs -n 1 dirname | sort -u | { echo "e2e"; cat; } | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -54,10 +54,10 @@ jobs:
         go-version: ['1.25.0', '1.26.0']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -89,7 +89,7 @@ jobs:
             done
           fi
 
-      - uses: codecov/codecov-action@v5.4.2
+      - uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,18 +27,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v6.1.0
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           config-name: release-drafter-config.yml

--- a/.github/workflows/tag-subpkg.yml
+++ b/.github/workflows/tag-subpkg.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Setup Git
         run: |

--- a/dockertest.sh
+++ b/dockertest.sh
@@ -4,7 +4,7 @@ set -ev
 
 go vet ./...
 
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 # disabled checks
 #  -ST1000 missing package doc in internal packages
 #  -ST1003 wrong naming convention would require breaking changes


### PR DESCRIPTION
Hi, I noticed from the OpenSSF scorecard for this project that some dependencies are not pinned: https://securityscorecards.dev/viewer/?uri=github.com/valkey-io/valkey-go.

As pinning dependencies is generally a good security practice to reduce the risk of supply-chain attacks, I've made the following changes:

- In `.github/workflows`: pin all GitHub Actions dependencies by hash, with a comment helping out to identify the version tag.
- In `dockertest.sh`, replace `latest` with the version tag, which is sufficient given the gosumdb infra.

With these changes, the OpenSSF score for `Pinned-Dependencies` goes from `1/10` to `10/10`:

### Before

```
❯ scorecard --checks=Pinned-Dependencies --repo=valkey-io/valkey-go
Starting (valkey-io/valkey-go) [Pinned-Dependencies]
Finished (valkey-io/valkey-go) [Pinned-Dependencies]

RESULTS
-------
Aggregate score: 1.0 / 10

Check scores:
|--------|---------------------|-----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
| SCORE  |        NAME         |                             REASON                              |                                            DOCUMENTATION / REMEDIATION                                             |
|--------|---------------------|-----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
| 1 / 10 | Pinned-Dependencies | dependency not pinned by hash detected -- score normalized to 1 | https://github.com/ossf/scorecard/blob/c395761df6afe1a69e476bc60a013a94bcbc153f/docs/checks.md#pinned-dependencies |
|--------|---------------------|-----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
```

### After

```
❯ scorecard --checks=Pinned-Dependencies --local .
Starting (.) [Pinned-Dependencies]
Finished (.) [Pinned-Dependencies]

RESULTS
-------
Aggregate score: 10.0 / 10

Check scores:
|---------|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
|  SCORE  |        NAME         |           REASON            |                                            DOCUMENTATION / REMEDIATION                                             |
|---------|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Pinned-Dependencies | all dependencies are pinned | https://github.com/ossf/scorecard/blob/c395761df6afe1a69e476bc60a013a94bcbc153f/docs/checks.md#pinned-dependencies |
|---------|---------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
```