### PR TITLE
Fall back to redis tag for go-redis compatibility

### DIFF
--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -6654,6 +6654,9 @@ func appendStructField(v reflect.Value) []string {
 	dst := make([]string, 0, typ.NumField())
 	for i := 0; i < typ.NumField(); i++ {
 		tag := typ.Field(i).Tag.Get("valkey")
+		if tag == "" {
+			tag = typ.Field(i).Tag.Get("redis")
+		}
 		if tag == "" || tag == "-" {
 			continue
 		}

--- a/valkeycompat/hscan_test.go
+++ b/valkeycompat/hscan_test.go
@@ -28,6 +28,7 @@ package valkeycompat
 
 import (
 	"math"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -236,6 +237,25 @@ var _ = Describe("Scan", func() {
 		Expect(d).To(Equal(data{
 			String: "str!",
 		}))
+	})
+
+	It("falls back to redis tag when valkey tag is missing", func() {
+		type goRedis struct {
+			Name string `redis:"name"`
+			Age  int    `redis:"age"`
+		}
+		var g goRedis
+		Expect(Scan(&g, []string{"name", "age"}, i{"alice", "30"})).NotTo(HaveOccurred())
+		Expect(g).To(Equal(goRedis{Name: "alice", Age: 30}))
+		Expect(appendStructField(reflect.ValueOf(goRedis{Name: "alice", Age: 30}))).To(Equal([]string{"name", "alice", "age", "30"}))
+
+		type both struct {
+			Name string `redis:"redis_name" valkey:"valkey_name"`
+		}
+		var b both
+		Expect(Scan(&b, []string{"valkey_name", "redis_name"}, i{"v", "r"})).NotTo(HaveOccurred())
+		Expect(b.Name).To(Equal("v"))
+		Expect(appendStructField(reflect.ValueOf(both{Name: "v"}))).To(Equal([]string{"valkey_name", "v"}))
 	})
 
 	It("catches bad values", func() {

--- a/valkeycompat/structmap.go
+++ b/valkeycompat/structmap.go
@@ -75,6 +75,9 @@ func newStructSpec(t reflect.Type, fieldTag string) *structSpec {
 		f := t.Field(i)
 
 		tag := f.Tag.Get(fieldTag)
+		if tag == "" {
+			tag = f.Tag.Get("redis")
+		}
 		if tag == "" || tag == "-" {
 			continue
 		}


### PR DESCRIPTION
A struct that works with go-redis is silently ignored by `valkeycompat`:

```go
type User struct {
    Name string `redis:"name"`
    Age  int    `redis:"age"`
}
```

`HGetAll(...).Scan(&u)` leaves every field zero, and `HSet(key, &u)` builds an `HSET` with no field/value pairs. To fix, users need to do

```go
type User struct {
    Name string `redis:"name" valkey:"name"`
    Age  int    `redis:"age"  valkey:"age"`
}
```

This PR makes both paths fall back to the `redis` tag when no `valkey` tag is present. `valkey` still wins when both are set.