### PR TITLE
Distribute # of calls to server during topology refresh

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -229,37 +229,15 @@ func getClusterSlots(c conn, timeout time.Duration) clusterslots {
 }
 
 func (c *clusterClient) _refresh() (err error) {
-	c.mu.RLock()
-	results := make(chan clusterslots, len(c.conns))
-	pending := make([]conn, 0, len(c.conns))
-	for _, cc := range c.conns {
-		pending = append(pending, cc.conn)
-	}
-	c.mu.RUnlock()
-
-	var result clusterslots
 	batchDelay := c.clusterRefreshBatchDelay()
-	for i := 0; i < cap(results); i++ {
-		if i&3 == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every 4 connections
-			if i > 0 && batchDelay > 0 {
-				time.Sleep(batchDelay)
-			}
-			for j := i; j < i+4 && j < len(pending); j++ {
-				go func(c conn, timeout time.Duration) {
-					results <- getClusterSlots(c, timeout)
-				}(pending[j], c.opt.ConnWriteTimeout)
-			}
-		}
-		result = <-results
-		err = result.reply.Error()
-		if len(result.reply.val.values()) != 0 {
-			break
-		}
+	preferred, fallback := c.clusterRefreshConns()
+	result, err := c.refreshConns(preferred, batchDelay)
+	if len(result.reply.val.values()) == 0 && len(fallback) > 0 {
+		result, err = c.refreshConns(fallback, batchDelay)
 	}
 	if err != nil {
 		return err
 	}
-	pending = nil
 
 	groups := result.parse(c.opt.TLSConfig != nil)
 	conns := make(map[string]connrole, len(groups))
@@ -384,6 +362,55 @@ func (c *clusterClient) _refresh() (err error) {
 	}
 
 	return nil
+}
+
+func (c *clusterClient) clusterRefreshConns() (preferred, fallback []conn) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.opt.ClusterOption.PreferInitAddressRefresh {
+		fallback = make([]conn, 0, len(c.conns))
+		for _, cc := range c.conns {
+			fallback = append(fallback, cc.conn)
+		}
+		return nil, fallback
+	}
+
+	initAddrs := make(map[string]struct{}, len(c.opt.InitAddress))
+	for _, addr := range c.opt.InitAddress {
+		initAddrs[addr] = struct{}{}
+		if cc, ok := c.conns[addr]; ok {
+			preferred = append(preferred, cc.conn)
+		}
+	}
+	fallback = make([]conn, 0, len(c.conns))
+	for addr, cc := range c.conns {
+		if _, ok := initAddrs[addr]; !ok {
+			fallback = append(fallback, cc.conn)
+		}
+	}
+	return preferred, fallback
+}
+
+func (c *clusterClient) refreshConns(pending []conn, batchDelay time.Duration) (result clusterslots, err error) {
+	results := make(chan clusterslots, len(pending))
+	for i := 0; i < len(pending); i++ {
+		if i&3 == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every 4 connections
+			if i > 0 && batchDelay > 0 {
+				time.Sleep(batchDelay)
+			}
+			for j := i; j < i+4 && j < len(pending); j++ {
+				go func(c conn, timeout time.Duration) {
+					results <- getClusterSlots(c, timeout)
+				}(pending[j], c.opt.ConnWriteTimeout)
+			}
+		}
+		result = <-results
+		err = result.reply.Error()
+		if len(result.reply.val.values()) != 0 {
+			break
+		}
+	}
+	return result, err
 }
 
 func (c *clusterClient) single() (conn conn) {

--- a/cluster.go
+++ b/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/rand"
 	"net"
 	"strconv"
 	"sync"
@@ -100,9 +101,6 @@ func newClusterClient(opt *ClientOption, connFn connFn, retryer retryHandler) (*
 		return nil, err
 	}
 
-	if d := client.clusterRefreshStartDelay(); d > 0 {
-		time.Sleep(d)
-	}
 	if err := client.refresh(context.Background()); err != nil {
 		return client, err
 	}
@@ -230,11 +228,7 @@ func getClusterSlots(c conn, timeout time.Duration) clusterslots {
 
 func (c *clusterClient) _refresh() (err error) {
 	batchDelay := c.clusterRefreshBatchDelay()
-	preferred, fallback := c.clusterRefreshConns()
-	result, err := c.refreshConns(preferred, batchDelay)
-	if len(result.reply.val.values()) == 0 && len(fallback) > 0 {
-		result, err = c.refreshConns(fallback, batchDelay)
-	}
+	result, err := c.refreshConns(c.clusterRefreshConns(), batchDelay)
 	if err != nil {
 		return err
 	}
@@ -364,31 +358,26 @@ func (c *clusterClient) _refresh() (err error) {
 	return nil
 }
 
-func (c *clusterClient) clusterRefreshConns() (preferred, fallback []conn) {
+func (c *clusterClient) clusterRefreshConns() []conn {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if !c.opt.ClusterOption.PreferInitAddressRefresh {
-		fallback = make([]conn, 0, len(c.conns))
+		pending := make([]conn, 0, len(c.conns))
 		for _, cc := range c.conns {
-			fallback = append(fallback, cc.conn)
+			pending = append(pending, cc.conn)
 		}
-		return nil, fallback
+		rand.Shuffle(len(pending), func(i, j int) { pending[i], pending[j] = pending[j], pending[i] })
+		return pending
 	}
 
-	initAddrs := make(map[string]struct{}, len(c.opt.InitAddress))
+	pending := make([]conn, 0, len(c.opt.InitAddress))
 	for _, addr := range c.opt.InitAddress {
-		initAddrs[addr] = struct{}{}
 		if cc, ok := c.conns[addr]; ok {
-			preferred = append(preferred, cc.conn)
+			pending = append(pending, cc.conn)
 		}
 	}
-	fallback = make([]conn, 0, len(c.conns))
-	for addr, cc := range c.conns {
-		if _, ok := initAddrs[addr]; !ok {
-			fallback = append(fallback, cc.conn)
-		}
-	}
-	return preferred, fallback
+	rand.Shuffle(len(pending), func(i, j int) { pending[i], pending[j] = pending[j], pending[i] })
+	return pending
 }
 
 func (c *clusterClient) refreshConns(pending []conn, batchDelay time.Duration) (result clusterslots, err error) {

--- a/cluster.go
+++ b/cluster.go
@@ -100,6 +100,9 @@ func newClusterClient(opt *ClientOption, connFn connFn, retryer retryHandler) (*
 		return nil, err
 	}
 
+	if d := client.clusterRefreshStartDelay(); d > 0 {
+		time.Sleep(d)
+	}
 	if err := client.refresh(context.Background()); err != nil {
 		return client, err
 	}
@@ -153,7 +156,60 @@ func (c *clusterClient) refresh(ctx context.Context) (err error) {
 }
 
 func (c *clusterClient) lazyRefresh() {
+	if c.opt.EnableClusterRefreshSpread {
+		c.sc.DelayDo(c.clusterRefreshStartDelay(), c._refresh)
+		return
+	}
 	c.sc.LazyDo(time.Second, c._refresh)
+}
+
+func (c *clusterClient) clusterRefreshStartDelay() time.Duration {
+	if !c.opt.EnableClusterRefreshSpread {
+		return 0
+	}
+	maxDelay := c.clusterRefreshMaxDelay()
+	return time.Duration(util.FastRand(int(maxDelay))) + time.Nanosecond
+}
+
+func (c *clusterClient) clusterRefreshMaxDelay() time.Duration {
+	if maxDelay := c.opt.ClusterRefreshMaxDelay; maxDelay > 0 {
+		return maxDelay
+	}
+	c.mu.RLock()
+	n := len(c.conns)
+	c.mu.RUnlock()
+	return clusterRefreshAutoMaxDelay(n)
+}
+
+func (c *clusterClient) clusterRefreshBatchDelay() time.Duration {
+	if !c.opt.EnableClusterRefreshSpread {
+		return 0
+	}
+	return clusterRefreshBatchDelayFromMaxDelay(c.clusterRefreshMaxDelay())
+}
+
+func clusterRefreshBatchDelayFromMaxDelay(maxDelay time.Duration) time.Duration {
+	switch {
+	case maxDelay <= time.Second:
+		return 0
+	case maxDelay >= 30*time.Second:
+		return 100 * time.Millisecond
+	default:
+		// Linearly scale 1s..30s max delay from 0ms to 100ms batch delay.
+		return (maxDelay - time.Second) * 100 * time.Millisecond / (29 * time.Second)
+	}
+}
+
+func clusterRefreshAutoMaxDelay(n int) time.Duration {
+	switch {
+	case n < 100:
+		return time.Second
+	case n >= 1000:
+		return 30 * time.Second
+	default:
+		// Linearly scale 100..1000 nodes from 1s to 30s.
+		return time.Second + time.Duration(n-100)*(29*time.Second)/900
+	}
 }
 
 type clusterslots struct {
@@ -195,9 +251,14 @@ func (c *clusterClient) _refresh() (err error) {
 	c.mu.RUnlock()
 
 	var result clusterslots
+	batchDelay := c.clusterRefreshBatchDelay()
+	n := 4
 	for i := 0; i < cap(results); i++ {
-		if i&3 == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every 4 connections
-			for j := i; j < i+4 && j < len(pending); j++ {
+		if i%n == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every n connections
+			if i > 0 && batchDelay > 0 {
+				time.Sleep(batchDelay)
+			}
+			for j := i; j < i+n && j < len(pending); j++ {
 				go func(c conn, timeout time.Duration) {
 					results <- getClusterSlots(c, timeout)
 				}(pending[j], c.opt.ConnWriteTimeout)

--- a/cluster.go
+++ b/cluster.go
@@ -159,7 +159,7 @@ func (c *clusterClient) lazyRefresh() {
 
 func (c *clusterClient) clusterRefreshStartDelay() time.Duration {
 	maxDelay := c.clusterRefreshMaxDelay()
-	return time.Duration(util.FastRand(int(maxDelay))) + time.Nanosecond
+	return time.Duration(util.FastRand(int(maxDelay)))
 }
 
 func (c *clusterClient) clusterRefreshMaxDelay() time.Duration {

--- a/cluster.go
+++ b/cluster.go
@@ -156,25 +156,15 @@ func (c *clusterClient) refresh(ctx context.Context) (err error) {
 }
 
 func (c *clusterClient) lazyRefresh() {
-	if c.opt.EnableClusterRefreshSpread {
-		c.sc.DelayDo(c.clusterRefreshStartDelay(), c._refresh)
-		return
-	}
-	c.sc.LazyDo(time.Second, c._refresh)
+	c.sc.DelayDo(c.clusterRefreshStartDelay(), c._refresh)
 }
 
 func (c *clusterClient) clusterRefreshStartDelay() time.Duration {
-	if !c.opt.EnableClusterRefreshSpread {
-		return 0
-	}
 	maxDelay := c.clusterRefreshMaxDelay()
 	return time.Duration(util.FastRand(int(maxDelay))) + time.Nanosecond
 }
 
 func (c *clusterClient) clusterRefreshMaxDelay() time.Duration {
-	if maxDelay := c.opt.ClusterRefreshMaxDelay; maxDelay > 0 {
-		return maxDelay
-	}
 	c.mu.RLock()
 	n := len(c.conns)
 	c.mu.RUnlock()
@@ -182,9 +172,6 @@ func (c *clusterClient) clusterRefreshMaxDelay() time.Duration {
 }
 
 func (c *clusterClient) clusterRefreshBatchDelay() time.Duration {
-	if !c.opt.EnableClusterRefreshSpread {
-		return 0
-	}
 	return clusterRefreshBatchDelayFromMaxDelay(c.clusterRefreshMaxDelay())
 }
 
@@ -252,13 +239,12 @@ func (c *clusterClient) _refresh() (err error) {
 
 	var result clusterslots
 	batchDelay := c.clusterRefreshBatchDelay()
-	n := 4
 	for i := 0; i < cap(results); i++ {
-		if i%n == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every n connections
+		if i&3 == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every 4 connections
 			if i > 0 && batchDelay > 0 {
 				time.Sleep(batchDelay)
 			}
-			for j := i; j < i+n && j < len(pending); j++ {
+			for j := i; j < i+4 && j < len(pending); j++ {
 				go func(c conn, timeout time.Duration) {
 					results <- getClusterSlots(c, timeout)
 				}(pending[j], c.opt.ConnWriteTimeout)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -10998,21 +10998,9 @@ func TestClusterRefreshBatchDelayFromMaxDelay(t *testing.T) {
 	}
 }
 
-func TestClusterRefreshStartDelayZeroWhenDisabled(t *testing.T) {
-	c := &clusterClient{opt: &ClientOption{
-		ClusterRefreshMaxDelay: 30 * time.Second,
-	}}
-	if d := c.clusterRefreshStartDelay(); d != 0 {
-		t.Fatalf("expected 0 with EnableClusterRefreshSpread disabled, got %v", d)
-	}
-}
-
 func TestClusterRefreshStartDelayWithinBound(t *testing.T) {
 	maxDelay := 30 * time.Second
-	c := &clusterClient{opt: &ClientOption{
-		EnableClusterRefreshSpread: true,
-		ClusterRefreshMaxDelay:     maxDelay,
-	}}
+	c := clusterClientWithConnCount(1000)
 	for i := 0; i < 1000; i++ {
 		d := c.clusterRefreshStartDelay()
 		if d <= 0 || d > maxDelay {
@@ -11023,10 +11011,7 @@ func TestClusterRefreshStartDelayWithinBound(t *testing.T) {
 
 func TestClusterRefreshStartDelayDistributesOverWindow(t *testing.T) {
 	maxDelay := 30 * time.Second
-	c := &clusterClient{opt: &ClientOption{
-		EnableClusterRefreshSpread: true,
-		ClusterRefreshMaxDelay:     maxDelay,
-	}}
+	c := clusterClientWithConnCount(1000)
 	const N = 10000
 	var sum, min, max time.Duration
 	min = maxDelay
@@ -11053,4 +11038,12 @@ func TestClusterRefreshStartDelayDistributesOverWindow(t *testing.T) {
 	if max < maxDelay*9/10 {
 		t.Fatalf("max %v too low, expected near %v", max, maxDelay)
 	}
+}
+
+func clusterClientWithConnCount(n int) *clusterClient {
+	conns := make(map[string]connrole, n)
+	for i := 0; i < n; i++ {
+		conns[fmt.Sprintf("%d", i)] = connrole{}
+	}
+	return &clusterClient{conns: conns}
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -10957,3 +10957,100 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 		}
 	}
 }
+
+func TestClusterRefreshAutoMaxDelay(t *testing.T) {
+	tests := []struct {
+		conns int
+		want  time.Duration
+	}{
+		{conns: 1, want: time.Second},
+		{conns: 99, want: time.Second},
+		{conns: 100, want: time.Second},
+		{conns: 550, want: 15500 * time.Millisecond},
+		{conns: 1000, want: 30 * time.Second},
+		{conns: 1200, want: 30 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.conns), func(t *testing.T) {
+			if got := clusterRefreshAutoMaxDelay(tt.conns); got != tt.want {
+				t.Fatalf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterRefreshBatchDelayFromMaxDelay(t *testing.T) {
+	tests := []struct {
+		maxDelay time.Duration
+		want     time.Duration
+	}{
+		{maxDelay: time.Second, want: 0},
+		{maxDelay: 15500 * time.Millisecond, want: 50 * time.Millisecond},
+		{maxDelay: 30 * time.Second, want: 100 * time.Millisecond},
+		{maxDelay: 60 * time.Second, want: 100 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.maxDelay.String(), func(t *testing.T) {
+			if got := clusterRefreshBatchDelayFromMaxDelay(tt.maxDelay); got != tt.want {
+				t.Fatalf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterRefreshStartDelayZeroWhenDisabled(t *testing.T) {
+	c := &clusterClient{opt: &ClientOption{
+		ClusterRefreshMaxDelay: 30 * time.Second,
+	}}
+	if d := c.clusterRefreshStartDelay(); d != 0 {
+		t.Fatalf("expected 0 with EnableClusterRefreshSpread disabled, got %v", d)
+	}
+}
+
+func TestClusterRefreshStartDelayWithinBound(t *testing.T) {
+	maxDelay := 30 * time.Second
+	c := &clusterClient{opt: &ClientOption{
+		EnableClusterRefreshSpread: true,
+		ClusterRefreshMaxDelay:     maxDelay,
+	}}
+	for i := 0; i < 1000; i++ {
+		d := c.clusterRefreshStartDelay()
+		if d <= 0 || d > maxDelay {
+			t.Fatalf("iteration %d: start delay %v out of (0, %v]", i, d, maxDelay)
+		}
+	}
+}
+
+func TestClusterRefreshStartDelayDistributesOverWindow(t *testing.T) {
+	maxDelay := 30 * time.Second
+	c := &clusterClient{opt: &ClientOption{
+		EnableClusterRefreshSpread: true,
+		ClusterRefreshMaxDelay:     maxDelay,
+	}}
+	const N = 10000
+	var sum, min, max time.Duration
+	min = maxDelay
+	for i := 0; i < N; i++ {
+		d := c.clusterRefreshStartDelay()
+		sum += d
+		if d < min {
+			min = d
+		}
+		if d > max {
+			max = d
+		}
+	}
+	avg := sum / N
+	expectedAvg := maxDelay / 2
+	lo := time.Duration(float64(expectedAvg) * 0.9)
+	hi := time.Duration(float64(expectedAvg) * 1.1)
+	if avg < lo || avg > hi {
+		t.Fatalf("avg %v outside expected [%v, %v]", avg, lo, hi)
+	}
+	if min <= 0 || min > maxDelay/100 {
+		t.Fatalf("min %v too high, expected near 0", min)
+	}
+	if max < maxDelay*9/10 {
+		t.Fatalf("max %v too low, expected near %v", max, maxDelay)
+	}
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -798,6 +798,86 @@ func TestClusterClientInit(t *testing.T) {
 		}
 	})
 
+	t.Run("Refresh prefers InitAddress and falls back", func(t *testing.T) {
+		var mu sync.Mutex
+		var calls []string
+		behavior := map[string]func() ValkeyResult{}
+		initAddrs := map[string]struct{}{
+			"127.0.0.1:0": {},
+		}
+		client, err := newClusterClient(
+			&ClientOption{
+				InitAddress: []string{"127.0.0.1:0"},
+				ClusterOption: ClusterOption{
+					PreferInitAddressRefresh: true,
+				},
+			},
+			func(dst string, opt *ClientOption) conn {
+				return &mockConn{
+					AddrFn: func() string { return dst },
+					DoFn: func(cmd Completed) ValkeyResult {
+						mu.Lock()
+						calls = append(calls, dst)
+						fn := behavior[dst]
+						mu.Unlock()
+						if fn != nil {
+							return fn()
+						}
+						return slotsMultiResp
+					},
+				}
+			},
+			newRetryer(defaultRetryDelayFn),
+		)
+		if err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+
+		resetCalls := func() {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = nil
+		}
+		snapshotCalls := func() []string {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]string(nil), calls...)
+		}
+		setBehavior := func(addr string, fn func() ValkeyResult) {
+			mu.Lock()
+			defer mu.Unlock()
+			behavior[addr] = fn
+		}
+		emptyResp := func() ValkeyResult {
+			return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+		}
+
+		resetCalls()
+		if err := client.refresh(context.Background()); err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+		for _, addr := range snapshotCalls() {
+			if _, ok := initAddrs[addr]; !ok {
+				t.Fatalf("unexpected fallback refresh call %v", addr)
+			}
+		}
+
+		setBehavior("127.0.0.1:0", emptyResp)
+		resetCalls()
+		if err := client.refresh(context.Background()); err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+		var fallbackCalled bool
+		for _, addr := range snapshotCalls() {
+			if _, ok := initAddrs[addr]; !ok {
+				fallbackCalled = true
+			}
+		}
+		if !fallbackCalled {
+			t.Fatalf("expected fallback refresh call")
+		}
+	})
+
 	t.Run("Refresh no slots cluster", func(t *testing.T) {
 		if _, err := newClusterClient(
 			&ClientOption{InitAddress: []string{":0"}},

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -798,7 +798,7 @@ func TestClusterClientInit(t *testing.T) {
 		}
 	})
 
-	t.Run("Refresh prefers InitAddress and falls back", func(t *testing.T) {
+	t.Run("Refresh prefers InitAddress only", func(t *testing.T) {
 		var mu sync.Mutex
 		var calls []string
 		behavior := map[string]func() ValkeyResult{}
@@ -873,8 +873,8 @@ func TestClusterClientInit(t *testing.T) {
 				fallbackCalled = true
 			}
 		}
-		if !fallbackCalled {
-			t.Fatalf("expected fallback refresh call")
+		if fallbackCalled {
+			t.Fatalf("unexpected fallback refresh call")
 		}
 	})
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -11083,8 +11083,8 @@ func TestClusterRefreshStartDelayWithinBound(t *testing.T) {
 	c := clusterClientWithConnCount(1000)
 	for i := 0; i < 1000; i++ {
 		d := c.clusterRefreshStartDelay()
-		if d <= 0 || d > maxDelay {
-			t.Fatalf("iteration %d: start delay %v out of (0, %v]", i, d, maxDelay)
+		if d < 0 || d >= maxDelay {
+			t.Fatalf("iteration %d: start delay %v out of [0, %v)", i, d, maxDelay)
 		}
 	}
 }
@@ -11112,7 +11112,7 @@ func TestClusterRefreshStartDelayDistributesOverWindow(t *testing.T) {
 	if avg < lo || avg > hi {
 		t.Fatalf("avg %v outside expected [%v, %v]", avg, lo, hi)
 	}
-	if min <= 0 || min > maxDelay/100 {
+	if min > maxDelay/100 {
 		t.Fatalf("min %v too high, expected near 0", min)
 	}
 	if max < maxDelay*9/10 {

--- a/singleflight.go
+++ b/singleflight.go
@@ -36,26 +36,7 @@ func (c *call) Do(ctx context.Context, fn func() error) error {
 	return c.do(ch, fn)
 }
 
-func (c *call) LazyDo(threshold time.Duration, fn func() error) {
-	c.mu.Lock()
-	ch := c.ch
-	if ch != nil {
-		c.mu.Unlock()
-		return
-	}
-	ch = make(chan struct{})
-	c.ch = ch
-	c.cn++
-	ts := c.ts
-	c.mu.Unlock()
-	go func(ts time.Time, ch chan struct{}, fn func() error) {
-		time.Sleep(time.Until(ts))
-		c.do(ch, fn)
-	}(ts.Add(threshold), ch, fn)
-}
-
 // DelayDo sleeps for delay then runs fn, deduping concurrent callers via singleflight.
-// Unlike LazyDo, it does not enforce a minimum gap since the last completion.
 func (c *call) DelayDo(delay time.Duration, fn func() error) {
 	c.mu.Lock()
 	ch := c.ch

--- a/singleflight.go
+++ b/singleflight.go
@@ -54,6 +54,25 @@ func (c *call) LazyDo(threshold time.Duration, fn func() error) {
 	}(ts.Add(threshold), ch, fn)
 }
 
+// DelayDo sleeps for delay then runs fn, deduping concurrent callers via singleflight.
+// Unlike LazyDo, it does not enforce a minimum gap since the last completion.
+func (c *call) DelayDo(delay time.Duration, fn func() error) {
+	c.mu.Lock()
+	ch := c.ch
+	if ch != nil {
+		c.mu.Unlock()
+		return
+	}
+	ch = make(chan struct{})
+	c.ch = ch
+	c.cn++
+	c.mu.Unlock()
+	go func(ch chan struct{}, fn func() error) {
+		time.Sleep(delay)
+		c.do(ch, fn)
+	}(ch, fn)
+}
+
 func (c *call) do(ch chan struct{}, fn func() error) (err error) {
 	err = fn()
 	c.mu.Lock()

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -83,28 +83,6 @@ func TestSingleFlightWithContext(t *testing.T) {
 	}
 }
 
-func TestSingleFlightLazyDo(t *testing.T) {
-	defer ShouldNotLeak(SetupLeakDetection())
-	ch := make(chan struct{})
-	sg := call{}
-	sg.LazyDo(time.Second, func() error {
-		<-ch
-		return nil
-	})
-	cn := 0
-	sg.LazyDo(time.Second, func() error {
-		cn++ // this should not occur
-		return nil
-	})
-	if cn != 0 {
-		t.Fatalf("unexpected cn %v", cn)
-	}
-	if sc := sg.suppressing(); sc != 1 {
-		t.Fatalf("unexpected suppressing %v", sc)
-	}
-	close(ch)
-}
-
 func TestSingleFlightDelayDoDedupesInFlight(t *testing.T) {
 	defer ShouldNotLeak(SetupLeakDetection())
 	ch := make(chan struct{})

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -104,3 +104,46 @@ func TestSingleFlightLazyDo(t *testing.T) {
 	}
 	close(ch)
 }
+
+func TestSingleFlightDelayDoDedupesInFlight(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+	ch := make(chan struct{})
+	sg := call{}
+	sg.DelayDo(0, func() error {
+		<-ch
+		return nil
+	})
+	cn := 0
+	sg.DelayDo(0, func() error {
+		cn++ // dedupe: should not run while first is in-flight
+		return nil
+	})
+	if cn != 0 {
+		t.Fatalf("DelayDo did not dedupe, cn=%v", cn)
+	}
+	if sc := sg.suppressing(); sc != 1 {
+		t.Fatalf("unexpected suppressing %v", sc)
+	}
+	close(ch)
+}
+
+func TestSingleFlightDelayDoHonorsDelay(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+	sg := call{}
+	delay := 75 * time.Millisecond
+	start := time.Now()
+	done := make(chan time.Time, 1)
+	sg.DelayDo(delay, func() error {
+		done <- time.Now()
+		return nil
+	})
+	select {
+	case ts := <-done:
+		got := ts.Sub(start)
+		if got < delay {
+			t.Fatalf("DelayDo ran too early: waited %v, expected >= %v", got, delay)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("DelayDo never ran")
+	}
+}

--- a/valkey.go
+++ b/valkey.go
@@ -243,15 +243,6 @@ type ClientOption struct {
 	// produce notable CPU usage reduction under load. Ref: https://github.com/redis/rueidis/issues/156
 	MaxFlushDelay time.Duration
 
-	// EnableClusterRefreshSpread spreads lazy cluster topology refreshes across a delay window.
-	// Default false keeps upstream LazyDo behavior unchanged.
-	EnableClusterRefreshSpread bool
-
-	// ClusterRefreshMaxDelay is the maximum delay before a lazy cluster topology refresh starts.
-	// It is only used when EnableClusterRefreshSpread is true. When zero, the max delay is
-	// derived from the current cluster connection count.
-	ClusterRefreshMaxDelay time.Duration
-
 	// ClusterOption is the options for the valkey cluster client.
 	ClusterOption ClusterOption
 

--- a/valkey.go
+++ b/valkey.go
@@ -310,8 +310,7 @@ type ClusterOption struct {
 	// Cluster topology cache refresh happens always in the background after a successful scan.
 	ShardsRefreshInterval time.Duration
 
-	// PreferInitAddressRefresh tries ClientOption.InitAddress nodes first during cluster topology refresh.
-	// If they do not return topology, refresh falls back to other known cluster connections.
+	// PreferInitAddressRefresh only uses ClientOption.InitAddress nodes during cluster topology refresh.
 	PreferInitAddressRefresh bool
 
 	// MaxMovedRedirections is the maximum number of times to retry a command when receiving MOVED|ASK responses.

--- a/valkey.go
+++ b/valkey.go
@@ -243,6 +243,15 @@ type ClientOption struct {
 	// produce notable CPU usage reduction under load. Ref: https://github.com/redis/rueidis/issues/156
 	MaxFlushDelay time.Duration
 
+	// EnableClusterRefreshSpread spreads lazy cluster topology refreshes across a delay window.
+	// Default false keeps upstream LazyDo behavior unchanged.
+	EnableClusterRefreshSpread bool
+
+	// ClusterRefreshMaxDelay is the maximum delay before a lazy cluster topology refresh starts.
+	// It is only used when EnableClusterRefreshSpread is true. When zero, the max delay is
+	// derived from the current cluster connection count.
+	ClusterRefreshMaxDelay time.Duration
+
 	// ClusterOption is the options for the valkey cluster client.
 	ClusterOption ClusterOption
 

--- a/valkey.go
+++ b/valkey.go
@@ -310,6 +310,10 @@ type ClusterOption struct {
 	// Cluster topology cache refresh happens always in the background after a successful scan.
 	ShardsRefreshInterval time.Duration
 
+	// PreferInitAddressRefresh tries ClientOption.InitAddress nodes first during cluster topology refresh.
+	// If they do not return topology, refresh falls back to other known cluster connections.
+	PreferInitAddressRefresh bool
+
 	// MaxMovedRedirections is the maximum number of times to retry a command when receiving MOVED|ASK responses.
 	// If set to 0 (default), MOVED|ASK retries will continue until the context timeout.
 	// If set to a positive value, the client will return an error after that many MOVED|ASK redirects.

--- a/valkey.go
+++ b/valkey.go
@@ -310,14 +310,14 @@ type ClusterOption struct {
 	// Cluster topology cache refresh happens always in the background after a successful scan.
 	ShardsRefreshInterval time.Duration
 
-	// PreferInitAddressRefresh only uses ClientOption.InitAddress nodes during cluster topology refresh.
-	PreferInitAddressRefresh bool
-
 	// MaxMovedRedirections is the maximum number of times to retry a command when receiving MOVED|ASK responses.
 	// If set to 0 (default), MOVED|ASK retries will continue until the context timeout.
 	// If set to a positive value, the client will return an error after that many MOVED|ASK redirects.
 	// This helps prevent infinite redirect loops in case of cluster misconfiguration.
 	MaxMovedRedirections int
+
+	// PreferInitAddressRefresh only uses ClientOption.InitAddress nodes during cluster topology refresh.
+	PreferInitAddressRefresh bool
 }
 
 // StandaloneOption is the options for the standalone client.


### PR DESCRIPTION
See https://github.com/valkey-io/valkey-go/issues/140 for info

This PR introduces default topology refresh behavior, reducing the storm of CLUSTER SHARD/SLOT calls to the Valkey server when the refresh happens.

## On close

Before: The client sends CLUSTER SHARDS call to all nodes 1 second after connection is closed.

After: The client sends CLUSTER SHARDS call to nodes [0,n] seconds after connection is closed. n depends on # of nodes the client is connected to, starting at 1 second for 100 nodes, and up to 30 seconds for 1000+ nodes.

## Batch calls

Before: The client sends CLUSTER SHARDS calls to all nodes at the same time (after the 1 second has passed). There is no delay between calls.

After: The client has delay between calls from 0 to 100ms. It is zero for less than 100 nodes, and up to 100ms for 1000+ nodes.

## Prefer init address on refresh

To further reduce the number of calls made, we introduce `ClusterOptions.PreferInitAddressRefresh` (false by default) which can be set if we can trust the addresses provided on `InitAddress` to exist after a topology refresh. It will call connections to all nodes in `InitAddress` on refresh.


## Testing

Ran two clusters at smaller scale (400 primaries, zero replicas), and had two 1000 k8 pods - one with valkey-go and other with rueidis client - doing 50 HMGET/s to them. Then I ran `systemctl stop valkey-server` for 5 minutes, and started it after.

valkey-go w/ this change (EnableClusterRefreshSpread enabled)
<img width="1053" height="313" alt="image" src="https://github.com/user-attachments/assets/4f7cbfbc-05d2-446b-927f-91317d5d3976" />

rueidis:
<img width="1020" height="306" alt="image" src="https://github.com/user-attachments/assets/fab63292-3e42-49cf-941b-1836df447095" />


----

I do ask for feedback on this, I think this is necessary but wanted to see community's opinion on the numbers we use.

Because this information is very specific valkey-go information, I wanted to internalize a lot of this by using # of nodes the client connected to, but I am not strongly opinionated on what should stay in and what should be exposed.
   - delay between each refresh (1 to 30 seconds if EnableClusterRefreshSpread enabled)
   - delay between batch search (0 to 100ms if EnableClusterRefreshSpread enabled)
   - number of connections to batch per iteration (left it at 4)

I do know that with 1 second refresh time, and no rate limit on checking topology, we will see this storm happen with really large clusters.

-----

Old description:



~~This PR introduces two knobs, whose defaults are what valkey-go uses today (so no changes to existing code, fully backwards compatible).~~

- ~~EnableClusterRefreshSpread: (default: false) when enabled, the topology refresh is distributed in a random period of time, which we configure based on the size of the cluster.~~
    - ~~n< 100 nodes: 1 second~~
    - ~~100≤n<1000: linear from 1 to 30 seconds~~
    - ~~n≥1000: 30 seconds~~

- ~~ClusterRefreshMaxDelay: a separate max distribution (will override the 1-30 seconds if set)~~
----