### PR TITLE
Expose and Use Constructors for ValkeyResults rather than Unsafe Pointer Conversions

### DIFF
--- a/client.go
+++ b/client.go
@@ -272,7 +272,7 @@ func (c *dedicatedSingleClient) Do(ctx context.Context, cmd Completed) (resp Val
 	attempts := 1
 retry:
 	if err := c.check(); err != nil {
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 	resp = c.wire.Do(ctx, cmd)
 	if c.retry && cmd.IsRetryable() && isRetryable(resp.Error(), c.wire, ctx) {

--- a/client.go
+++ b/client.go
@@ -272,7 +272,7 @@ func (c *dedicatedSingleClient) Do(ctx context.Context, cmd Completed) (resp Val
 	attempts := 1
 retry:
 	if err := c.check(); err != nil {
-		return newErrResult(err)
+		return NewErrorResult(err)
 	}
 	resp = c.wire.Do(ctx, cmd)
 	if c.retry && cmd.IsRetryable() && isRetryable(resp.Error(), c.wire, ctx) {

--- a/client.go
+++ b/client.go
@@ -77,7 +77,7 @@ func (c *singleClient) DoStream(ctx context.Context, cmd Completed) ValkeyResult
 
 func (c *singleClient) DoMultiStream(ctx context.Context, multi ...Completed) MultiValkeyResultStream {
 	if len(multi) == 0 {
-		return ValkeyResultStream{e: io.EOF}
+		return NewErrorResultStream(io.EOF)
 	}
 	s := c.conn.DoMultiStream(ctx, multi...)
 	for _, cmd := range multi {

--- a/client.go
+++ b/client.go
@@ -272,7 +272,7 @@ func (c *dedicatedSingleClient) Do(ctx context.Context, cmd Completed) (resp Val
 	attempts := 1
 retry:
 	if err := c.check(); err != nil {
-		return NewErrResult(err)
+		return newErrResult(err)
 	}
 	resp = c.wire.Do(ctx, cmd)
 	if c.retry && cmd.IsRetryable() && isRetryable(resp.Error(), c.wire, ctx) {

--- a/client_test.go
+++ b/client_test.go
@@ -284,7 +284,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return NewResult(strmsg('+', "Do"), nil)
+			return newResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -307,7 +307,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Do"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -336,7 +336,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return NewResult(strmsg('+', "DoCache"), nil)
+			return newResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -349,7 +349,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "DoCache"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -423,10 +423,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -489,10 +489,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -691,8 +691,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Do ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -701,7 +701,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do ReadOnly NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
+		m.DoFn = makeDoFn(newErrResult(ErrClosing))
 		c.Close()
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -710,7 +710,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
+		m.DoFn = makeDoFn(newErrResult(ErrClosing))
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.Do(ctx, c.B().Get().Key("Do").Build()).ToString(); err != ErrClosing {
@@ -742,8 +742,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoFn = makeDoFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -752,7 +752,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
+		m.DoFn = makeDoFn(newErrResult(ErrClosing))
 		if v, err := c.Do(context.Background(), c.B().Set().Key("Do").Value("V").Build()).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
 		}
@@ -761,8 +761,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Do Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -772,8 +772,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMulti ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -782,7 +782,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti ReadOnly NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
 		c.Close()
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -791,7 +791,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoMulti(ctx, c.B().Get().Key("Do").Build())[0].ToString(); err != ErrClosing {
@@ -831,8 +831,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -841,7 +841,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
 		if v, err := c.DoMulti(context.Background(), c.B().Set().Key("Do").Value("V").Build())[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
 		}
@@ -850,8 +850,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMulti Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -861,8 +861,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoCache Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoCacheFn = makeDoCacheFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -871,7 +871,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoCache NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoCacheFn = makeDoCacheFn(NewErrResult(ErrClosing))
+		m.DoCacheFn = makeDoCacheFn(newErrResult(ErrClosing))
 		c.Close()
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -880,7 +880,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoCache ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoCacheFn = makeDoCacheFn(NewErrResult(ErrClosing))
+		m.DoCacheFn = makeDoCacheFn(newErrResult(ErrClosing))
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoCache(ctx, c.B().Get().Key("Do").Cache(), 0).ToString(); err != ErrClosing {
@@ -912,8 +912,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoCacheFn = makeDoCacheFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -923,8 +923,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMultiCache Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -933,7 +933,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMultiCache NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{newErrResult(ErrClosing)})
 		c.Close()
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -942,7 +942,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMultiCache ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{newErrResult(ErrClosing)})
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoMultiCache(ctx, CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != ErrClosing {
@@ -982,8 +982,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1049,8 +1049,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1065,7 +1065,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
+		m.DoFn = makeDoFn(newErrResult(ErrClosing))
 		m.ErrorFn = func() error { return ErrClosing }
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1077,7 +1077,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
+		m.DoFn = makeDoFn(newErrResult(ErrClosing))
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -1091,8 +1091,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - not retryable", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1122,7 +1122,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
+		m.DoFn = makeDoFn(newErrResult(ErrClosing))
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.Do(context.Background(), c.B().Set().Key("Do").Value("Do").Build()).Error()
@@ -1134,8 +1134,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			NewErrResult(ErrClosing),
-			NewResult(strmsg('+', "Do"), nil),
+			newErrResult(ErrClosing),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1151,8 +1151,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1167,7 +1167,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
 		m.ErrorFn = func() error { return ErrClosing }
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1179,7 +1179,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -1193,8 +1193,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - not retryable", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1224,7 +1224,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.DoMulti(context.Background(), c.B().Set().Key("Do").Value("Do").Build())[0].Error()
@@ -1236,8 +1236,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{NewErrResult(ErrClosing)},
-			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1342,9 +1342,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1361,9 +1361,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "ERR some other error"), nil)
+				return newResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -1380,9 +1380,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -1401,9 +1401,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1418,9 +1418,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1439,9 +1439,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -1462,9 +1462,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -1504,7 +1504,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("Do", func(t *testing.T) {
 		client, m := setup()
 		m.DoFn = func(cmd Completed) ValkeyResult {
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Get().Key("Do").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1514,7 +1514,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("DoMulti", func(t *testing.T) {
 		client, m := setup()
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1527,9 +1527,9 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1542,10 +1542,10 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -1567,53 +1567,53 @@ func TestSingleClientConnLifetime(t *testing.T) {
 			switch attempts {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi Command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "1"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "1"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(slicemsg('*', []ValkeyMessage{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					NewErrResult(errConnExpired),
+					newErrResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -1650,7 +1650,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("DoMultiCache", func(t *testing.T) {
 		client, m := setup()
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		cmd := client.B().Get().Key("Do").Cache()
 		if v, err := client.DoMultiCache(context.Background(), CT(cmd, 0))[0].ToString(); err != nil || v != "OK" {
@@ -1664,9 +1664,9 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		cmd := client.B().Get().Key("Do").Cache()
 		if v, err := client.DoMultiCache(context.Background(), CT(cmd, 0))[0].ToString(); err != nil || v != "OK" {
@@ -1680,10 +1680,10 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {

--- a/client_test.go
+++ b/client_test.go
@@ -284,7 +284,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -307,7 +307,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Do"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -336,7 +336,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -349,7 +349,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "DoCache"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -423,10 +423,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -489,10 +489,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -691,8 +691,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Do ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -701,7 +701,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do ReadOnly NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
 		c.Close()
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -710,7 +710,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.Do(ctx, c.B().Get().Key("Do").Build()).ToString(); err != ErrClosing {
@@ -742,8 +742,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -752,7 +752,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
 		if v, err := c.Do(context.Background(), c.B().Set().Key("Do").Value("V").Build()).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
 		}
@@ -761,8 +761,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Do Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -772,8 +772,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMulti ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -782,7 +782,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti ReadOnly NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		c.Close()
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -791,7 +791,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoMulti(ctx, c.B().Get().Key("Do").Build())[0].ToString(); err != ErrClosing {
@@ -831,8 +831,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -841,7 +841,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		if v, err := c.DoMulti(context.Background(), c.B().Set().Key("Do").Value("V").Build())[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
 		}
@@ -850,8 +850,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMulti Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -861,8 +861,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoCache Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoCacheFn = makeDoCacheFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -871,7 +871,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoCache NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoCacheFn = makeDoCacheFn(newErrResult(ErrClosing))
+		m.DoCacheFn = makeDoCacheFn(NewErrResult(ErrClosing))
 		c.Close()
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -880,7 +880,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoCache ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoCacheFn = makeDoCacheFn(newErrResult(ErrClosing))
+		m.DoCacheFn = makeDoCacheFn(NewErrResult(ErrClosing))
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoCache(ctx, c.B().Get().Key("Do").Cache(), 0).ToString(); err != ErrClosing {
@@ -912,8 +912,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoCacheFn = makeDoCacheFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -923,8 +923,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMultiCache Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -933,7 +933,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMultiCache NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		c.Close()
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -942,7 +942,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMultiCache ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoMultiCache(ctx, CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != ErrClosing {
@@ -982,8 +982,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1049,8 +1049,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1065,7 +1065,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
 		m.ErrorFn = func() error { return ErrClosing }
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1077,7 +1077,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -1091,8 +1091,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - not retryable", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1122,7 +1122,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrResult(ErrClosing))
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.Do(context.Background(), c.B().Set().Key("Do").Value("Do").Build()).Error()
@@ -1134,8 +1134,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewErrResult(ErrClosing),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1151,8 +1151,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1167,7 +1167,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		m.ErrorFn = func() error { return ErrClosing }
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1179,7 +1179,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -1193,8 +1193,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - not retryable", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1224,7 +1224,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrResult(ErrClosing)})
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.DoMulti(context.Background(), c.B().Set().Key("Do").Value("Do").Build())[0].Error()
@@ -1236,8 +1236,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewErrResult(ErrClosing)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1342,9 +1342,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1361,9 +1361,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "ERR some other error"), nil)
+				return NewResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -1380,9 +1380,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -1401,9 +1401,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1418,9 +1418,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1439,9 +1439,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -1462,9 +1462,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -1504,7 +1504,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("Do", func(t *testing.T) {
 		client, m := setup()
 		m.DoFn = func(cmd Completed) ValkeyResult {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Get().Key("Do").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1514,7 +1514,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("DoMulti", func(t *testing.T) {
 		client, m := setup()
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1527,9 +1527,9 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1542,10 +1542,10 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -1567,53 +1567,53 @@ func TestSingleClientConnLifetime(t *testing.T) {
 			switch attempts {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi Command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "1"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newErrResult(errConnExpired),
+					NewErrResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -1650,7 +1650,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("DoMultiCache", func(t *testing.T) {
 		client, m := setup()
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		cmd := client.B().Get().Key("Do").Cache()
 		if v, err := client.DoMultiCache(context.Background(), CT(cmd, 0))[0].ToString(); err != nil || v != "OK" {
@@ -1664,9 +1664,9 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		cmd := client.B().Get().Key("Do").Cache()
 		if v, err := client.DoMultiCache(context.Background(), CT(cmd, 0))[0].ToString(); err != nil || v != "OK" {
@@ -1680,10 +1680,10 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {

--- a/client_test.go
+++ b/client_test.go
@@ -284,7 +284,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -307,7 +307,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Do"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -336,7 +336,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -349,7 +349,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "DoCache"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -423,10 +423,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -489,10 +489,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -692,7 +692,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -743,7 +743,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoFn = makeDoFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -762,7 +762,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -773,7 +773,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -832,7 +832,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoMultiFn = makeDoMultiFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -851,7 +851,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -862,7 +862,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoCacheFn = makeDoCacheFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -913,7 +913,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoCacheFn = makeDoCacheFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -924,7 +924,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -983,7 +983,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1050,7 +1050,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1092,7 +1092,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1135,7 +1135,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			NewErrorResult(ErrClosing),
-			newResult(strmsg('+', "Do"), nil),
+			NewResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1152,7 +1152,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1194,7 +1194,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1237,7 +1237,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]ValkeyResult{NewErrorResult(ErrClosing)},
-			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
+			[]ValkeyResult{NewResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1342,9 +1342,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1361,9 +1361,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "ERR some other error"), nil)
+				return NewResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -1380,9 +1380,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -1401,9 +1401,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1418,9 +1418,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1439,9 +1439,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -1462,9 +1462,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -1504,7 +1504,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("Do", func(t *testing.T) {
 		client, m := setup()
 		m.DoFn = func(cmd Completed) ValkeyResult {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Get().Key("Do").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1514,7 +1514,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("DoMulti", func(t *testing.T) {
 		client, m := setup()
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1529,7 +1529,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1542,10 +1542,10 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -1573,7 +1573,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "1"), nil),
+					NewResult(strmsg('+', "1"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
@@ -1581,8 +1581,8 @@ func TestSingleClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
@@ -1590,19 +1590,19 @@ func TestSingleClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
@@ -1613,7 +1613,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -1650,7 +1650,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 	t.Run("DoMultiCache", func(t *testing.T) {
 		client, m := setup()
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		cmd := client.B().Get().Key("Do").Cache()
 		if v, err := client.DoMultiCache(context.Background(), CT(cmd, 0))[0].ToString(); err != nil || v != "OK" {
@@ -1666,7 +1666,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		cmd := client.B().Get().Key("Do").Cache()
 		if v, err := client.DoMultiCache(context.Background(), CT(cmd, 0))[0].ToString(); err != nil || v != "OK" {
@@ -1680,10 +1680,10 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {

--- a/client_test.go
+++ b/client_test.go
@@ -294,7 +294,7 @@ func TestSingleClient(t *testing.T) {
 	t.Run("Delegate DoStream", func(t *testing.T) {
 		c := client.B().Get().Key("Do").Build()
 		m.DoStreamFn = func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{e: errors.New(cmd.Commands()[1])}
+			return NewErrorResultStream(errors.New(cmd.Commands()[1]))
 		}
 		if s := client.DoStream(context.Background(), c); s.Error().Error() != "Do" {
 			t.Fatalf("unexpected response %v", s.Error())

--- a/client_test.go
+++ b/client_test.go
@@ -691,7 +691,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Do ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != nil || v != "Do" {
@@ -701,7 +701,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do ReadOnly NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrorResult(ErrClosing))
 		c.Close()
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -710,7 +710,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrorResult(ErrClosing))
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.Do(ctx, c.B().Get().Key("Do").Build()).ToString(); err != ErrClosing {
@@ -742,7 +742,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); !errors.Is(err, ErrClosing) {
@@ -752,7 +752,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate Do Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrorResult(ErrClosing))
 		if v, err := c.Do(context.Background(), c.B().Set().Key("Do").Value("V").Build()).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
 		}
@@ -761,7 +761,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Do Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable()).ToString(); err != nil || v != "Do" {
@@ -772,7 +772,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMulti ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "Do" {
@@ -782,7 +782,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti ReadOnly NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		c.Close()
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -791,7 +791,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoMulti(ctx, c.B().Get().Key("Do").Build())[0].ToString(); err != ErrClosing {
@@ -831,7 +831,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); !errors.Is(err, ErrClosing) {
@@ -841,7 +841,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMulti Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		if v, err := c.DoMulti(context.Background(), c.B().Set().Key("Do").Value("V").Build())[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
 		}
@@ -850,7 +850,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMulti Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Set().Key("Do").Value("V").Build().ToRetryable())[0].ToString(); err != nil || v != "Do" {
@@ -861,7 +861,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoCache Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoCacheFn = makeDoCacheFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "Do" {
@@ -871,7 +871,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoCache NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoCacheFn = makeDoCacheFn(newErrResult(ErrClosing))
+		m.DoCacheFn = makeDoCacheFn(NewErrorResult(ErrClosing))
 		c.Close()
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -880,7 +880,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoCache ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoCacheFn = makeDoCacheFn(newErrResult(ErrClosing))
+		m.DoCacheFn = makeDoCacheFn(NewErrorResult(ErrClosing))
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoCache(ctx, c.B().Get().Key("Do").Cache(), 0).ToString(); err != ErrClosing {
@@ -912,7 +912,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoCacheFn = makeDoCacheFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); !errors.Is(err, ErrClosing) {
@@ -923,7 +923,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate DoMultiCache Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "Do" {
@@ -933,7 +933,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMultiCache NoRetry - closed", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		c.Close()
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != ErrClosing {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -942,7 +942,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Delegate DoMultiCache ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiCacheFn = makeDoMultiCacheFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if v, err := c.DoMultiCache(ctx, CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != ErrClosing {
@@ -982,7 +982,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			}
 		}
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); !errors.Is(err, ErrClosing) {
@@ -1049,7 +1049,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
@@ -1065,7 +1065,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrorResult(ErrClosing))
 		m.ErrorFn = func() error { return ErrClosing }
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1077,7 +1077,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrorResult(ErrClosing))
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -1091,7 +1091,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - not retryable", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
@@ -1122,7 +1122,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate Do Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoFn = makeDoFn(newErrResult(ErrClosing))
+		m.DoFn = makeDoFn(NewErrorResult(ErrClosing))
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.Do(context.Background(), c.B().Set().Key("Do").Value("Do").Build()).Error()
@@ -1134,7 +1134,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
-			newErrResult(ErrClosing),
+			NewErrorResult(ErrClosing),
 			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
@@ -1151,7 +1151,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
@@ -1167,7 +1167,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		m.ErrorFn = func() error { return ErrClosing }
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1179,7 +1179,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -1193,7 +1193,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - not retryable", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
@@ -1224,7 +1224,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 
 	t.Run("Dedicate Delegate DoMulti Write NoRetry", func(t *testing.T) {
 		c, m := setup()
-		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{newErrResult(ErrClosing)})
+		m.DoMultiFn = makeDoMultiFn([]ValkeyResult{NewErrorResult(ErrClosing)})
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.DoMulti(context.Background(), c.B().Set().Key("Do").Value("Do").Build())[0].Error()
@@ -1236,7 +1236,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti Write Retryable Retry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
-			[]ValkeyResult{newErrResult(ErrClosing)},
+			[]ValkeyResult{NewErrorResult(ErrClosing)},
 			[]ValkeyResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
@@ -1527,7 +1527,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -1542,7 +1542,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
@@ -1567,14 +1567,14 @@ func TestSingleClientConnLifetime(t *testing.T) {
 			switch attempts {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi Command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
@@ -1583,7 +1583,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
@@ -1593,7 +1593,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
@@ -1606,7 +1606,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
@@ -1664,7 +1664,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -1680,7 +1680,7 @@ func TestSingleClientConnLifetime(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}

--- a/cluster.go
+++ b/cluster.go
@@ -615,7 +615,7 @@ func (c *clusterClient) do(ctx context.Context, cmd Completed) (resp ValkeyResul
 retry:
 	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(cmd))
 	if err != nil {
-		return NewErrResult(err)
+		return newErrResult(err)
 	}
 	resp = cc.Do(ctx, cmd)
 	if resp.NonValkeyError() == errConnExpired {
@@ -1001,7 +1001,7 @@ retry:
 func fillErrs(n int, err error) (results []ValkeyResult) {
 	results = resultsp.Get(n, n).s
 	for i := range results {
-		results[i] = NewErrResult(err)
+		results[i] = newErrResult(err)
 	}
 	return results
 }
@@ -1013,7 +1013,7 @@ func (c *clusterClient) doCache(ctx context.Context, cmd Cacheable, ttl time.Dur
 retry:
 	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(Completed(cmd)))
 	if err != nil {
-		return NewErrResult(err)
+		return newErrResult(err)
 	}
 	resp = cc.DoCache(ctx, cmd, ttl)
 	if resp.NonValkeyError() == errConnExpired {
@@ -1170,9 +1170,9 @@ func (c *clusterClient) askingMultiCache(cc conn, ctx context.Context, multi []C
 				if preErr := resps.s[i-1].Error(); preErr != nil { // if {Cmd} get a ValkeyError
 					err = preErr
 				}
-				results.s = append(results.s, NewErrResult(err))
+				results.s = append(results.s, newErrResult(err))
 			} else {
-				results.s = append(results.s, NewResult(arr[len(arr)-1], nil))
+				results.s = append(results.s, newResult(arr[len(arr)-1], nil))
 			}
 		}
 	}
@@ -1611,7 +1611,7 @@ func (c *dedicatedClusterClient) Do(ctx context.Context, cmd Completed) (resp Va
 	attempts := 1
 retry:
 	if w, err := c.acquire(ctx, cmd.Slot()); err != nil {
-		resp = NewErrResult(err)
+		resp = newErrResult(err)
 	} else {
 		resp = w.Do(ctx, cmd)
 		switch _, mode := c.client.shouldRefreshRetry(resp.Error(), ctx); mode {
@@ -1667,7 +1667,7 @@ retry:
 	} else {
 		resp = resultsp.Get(len(multi), len(multi)).s
 		for i := range resp {
-			resp[i] = NewErrResult(err)
+			resp[i] = newErrResult(err)
 		}
 	}
 	for i, cmd := range multi {

--- a/cluster.go
+++ b/cluster.go
@@ -615,7 +615,7 @@ func (c *clusterClient) do(ctx context.Context, cmd Completed) (resp ValkeyResul
 retry:
 	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(cmd))
 	if err != nil {
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 	resp = cc.Do(ctx, cmd)
 	if resp.NonValkeyError() == errConnExpired {
@@ -1001,7 +1001,7 @@ retry:
 func fillErrs(n int, err error) (results []ValkeyResult) {
 	results = resultsp.Get(n, n).s
 	for i := range results {
-		results[i] = newErrResult(err)
+		results[i] = NewErrResult(err)
 	}
 	return results
 }
@@ -1013,7 +1013,7 @@ func (c *clusterClient) doCache(ctx context.Context, cmd Cacheable, ttl time.Dur
 retry:
 	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(Completed(cmd)))
 	if err != nil {
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 	resp = cc.DoCache(ctx, cmd, ttl)
 	if resp.NonValkeyError() == errConnExpired {
@@ -1170,9 +1170,9 @@ func (c *clusterClient) askingMultiCache(cc conn, ctx context.Context, multi []C
 				if preErr := resps.s[i-1].Error(); preErr != nil { // if {Cmd} get a ValkeyError
 					err = preErr
 				}
-				results.s = append(results.s, newErrResult(err))
+				results.s = append(results.s, NewErrResult(err))
 			} else {
-				results.s = append(results.s, newResult(arr[len(arr)-1], nil))
+				results.s = append(results.s, NewResult(arr[len(arr)-1], nil))
 			}
 		}
 	}
@@ -1611,7 +1611,7 @@ func (c *dedicatedClusterClient) Do(ctx context.Context, cmd Completed) (resp Va
 	attempts := 1
 retry:
 	if w, err := c.acquire(ctx, cmd.Slot()); err != nil {
-		resp = newErrResult(err)
+		resp = NewErrResult(err)
 	} else {
 		resp = w.Do(ctx, cmd)
 		switch _, mode := c.client.shouldRefreshRetry(resp.Error(), ctx); mode {
@@ -1667,7 +1667,7 @@ retry:
 	} else {
 		resp = resultsp.Get(len(multi), len(multi)).s
 		for i := range resp {
-			resp[i] = newErrResult(err)
+			resp[i] = NewErrResult(err)
 		}
 	}
 	for i, cmd := range multi {

--- a/cluster.go
+++ b/cluster.go
@@ -615,7 +615,7 @@ func (c *clusterClient) do(ctx context.Context, cmd Completed) (resp ValkeyResul
 retry:
 	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(cmd))
 	if err != nil {
-		return newErrResult(err)
+		return NewErrorResult(err)
 	}
 	resp = cc.Do(ctx, cmd)
 	if resp.NonValkeyError() == errConnExpired {
@@ -1001,7 +1001,7 @@ retry:
 func fillErrs(n int, err error) (results []ValkeyResult) {
 	results = resultsp.Get(n, n).s
 	for i := range results {
-		results[i] = newErrResult(err)
+		results[i] = NewErrorResult(err)
 	}
 	return results
 }
@@ -1013,7 +1013,7 @@ func (c *clusterClient) doCache(ctx context.Context, cmd Cacheable, ttl time.Dur
 retry:
 	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(Completed(cmd)))
 	if err != nil {
-		return newErrResult(err)
+		return NewErrorResult(err)
 	}
 	resp = cc.DoCache(ctx, cmd, ttl)
 	if resp.NonValkeyError() == errConnExpired {
@@ -1170,7 +1170,7 @@ func (c *clusterClient) askingMultiCache(cc conn, ctx context.Context, multi []C
 				if preErr := resps.s[i-1].Error(); preErr != nil { // if {Cmd} get a ValkeyError
 					err = preErr
 				}
-				results.s = append(results.s, newErrResult(err))
+				results.s = append(results.s, NewErrorResult(err))
 			} else {
 				results.s = append(results.s, newResult(arr[len(arr)-1], nil))
 			}
@@ -1611,7 +1611,7 @@ func (c *dedicatedClusterClient) Do(ctx context.Context, cmd Completed) (resp Va
 	attempts := 1
 retry:
 	if w, err := c.acquire(ctx, cmd.Slot()); err != nil {
-		resp = newErrResult(err)
+		resp = NewErrorResult(err)
 	} else {
 		resp = w.Do(ctx, cmd)
 		switch _, mode := c.client.shouldRefreshRetry(resp.Error(), ctx); mode {
@@ -1667,7 +1667,7 @@ retry:
 	} else {
 		resp = resultsp.Get(len(multi), len(multi)).s
 		for i := range resp {
-			resp[i] = newErrResult(err)
+			resp[i] = NewErrorResult(err)
 		}
 	}
 	for i, cmd := range multi {

--- a/cluster.go
+++ b/cluster.go
@@ -1172,7 +1172,7 @@ func (c *clusterClient) askingMultiCache(cc conn, ctx context.Context, multi []C
 				}
 				results.s = append(results.s, NewErrorResult(err))
 			} else {
-				results.s = append(results.s, newResult(arr[len(arr)-1], nil))
+				results.s = append(results.s, NewResult(arr[len(arr)-1], nil))
 			}
 		}
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -1444,7 +1444,7 @@ ret:
 func (c *clusterClient) DoStream(ctx context.Context, cmd Completed) ValkeyResultStream {
 	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(cmd))
 	if err != nil {
-		return ValkeyResultStream{e: err}
+		return NewErrorResultStream(err)
 	}
 	ret := cc.DoStream(ctx, cmd)
 	cmds.PutCompleted(cmd)
@@ -1453,7 +1453,7 @@ func (c *clusterClient) DoStream(ctx context.Context, cmd Completed) ValkeyResul
 
 func (c *clusterClient) DoMultiStream(ctx context.Context, multi ...Completed) MultiValkeyResultStream {
 	if len(multi) == 0 {
-		return ValkeyResultStream{e: io.EOF}
+		return NewErrorResultStream(io.EOF)
 	}
 	slot := multi[0].Slot()
 	repl := c.toReplica(multi[0])
@@ -1469,7 +1469,7 @@ func (c *clusterClient) DoMultiStream(ctx context.Context, multi ...Completed) M
 	}
 	cc, err := c.pick(ctx, slot, repl)
 	if err != nil {
-		return ValkeyResultStream{e: err}
+		return NewErrorResultStream(err)
 	}
 	ret := cc.DoMultiStream(ctx, multi...)
 	for _, cmd := range multi {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/valkey-io/valkey-go/internal/cmds"
 )
 
-var slotsResp = newResult(slicemsg('*', []ValkeyMessage{
+var slotsResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 16383},
@@ -35,7 +35,7 @@ var slotsResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -66,7 +66,7 @@ var slotsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiRespWithoutReplicas = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -87,7 +87,7 @@ var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiRespWithMultiReplicas = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -138,7 +138,7 @@ var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotResp = newResult(slicemsg('*', []ValkeyMessage{
+var singleSlotResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -150,7 +150,7 @@ var singleSlotResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotResp2 = newResult(slicemsg('*', []ValkeyMessage{
+var singleSlotResp2 = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -162,7 +162,7 @@ var singleSlotResp2 = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotWithoutIP = newResult(slicemsg('*', []ValkeyMessage{
+var singleSlotWithoutIP = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -188,7 +188,7 @@ var singleSlotWithoutIP = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsResp = newResult(slicemsg(typeArray, []ValkeyMessage{
+var shardsResp = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -267,7 +267,7 @@ var shardsResp = newResult(slicemsg(typeArray, []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsRespTls = newResult(slicemsg(typeArray, []ValkeyMessage{
+var shardsRespTls = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -374,7 +374,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
+var shardsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -529,7 +529,7 @@ var shardsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleShardResp2 = newResult(slicemsg('*', []ValkeyMessage{
+var singleShardResp2 = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -586,7 +586,7 @@ var singleShardResp2 = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleShardWithoutIP = newResult(slicemsg(typeArray, []ValkeyMessage{
+var singleShardWithoutIP = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -751,7 +751,7 @@ func TestClusterClientInit(t *testing.T) {
 		if _, err := newClusterClient(
 			&ClientOption{InitAddress: []string{":0"}},
 			func(dst string, opt *ClientOption) conn {
-				return &mockConn{DoFn: func(cmd Completed) ValkeyResult { return newErrResult(v) }}
+				return &mockConn{DoFn: func(cmd Completed) ValkeyResult { return NewErrResult(v) }}
 			},
 			newRetryer(defaultRetryDelayFn),
 		); err != v {
@@ -767,7 +767,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+							return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 						}
 						return slotsResp
 					},
@@ -787,7 +787,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+							return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 						}
 						return shardsResp
 					},
@@ -851,7 +851,7 @@ func TestClusterClientInit(t *testing.T) {
 			behavior[addr] = fn
 		}
 		emptyResp := func() ValkeyResult {
-			return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+			return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 		}
 
 		resetCalls()
@@ -886,7 +886,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
-						return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+						return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 					},
 				}
 			},
@@ -902,7 +902,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
-						return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+						return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 					},
 					VersionFn: func() int { return 8 },
 				}
@@ -1734,7 +1734,7 @@ func TestClusterClient(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -1744,21 +1744,21 @@ func TestClusterClient(t *testing.T) {
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Do"), nil)
+				return NewResult(strmsg('+', "Do"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Info"), nil)
+				return NewResult(strmsg('+', "Info"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "DoCache"), nil)
+				return NewResult(strmsg('+', "DoCache"), nil)
 			},
 		},
 	}
@@ -2009,9 +2009,9 @@ func TestClusterClient(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2072,23 +2072,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2180,23 +2180,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2394,40 +2394,40 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -2609,9 +2609,9 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2672,23 +2672,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2780,23 +2780,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2893,10 +2893,10 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 		},
 	}
@@ -2904,31 +2904,31 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -3098,9 +3098,9 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3164,23 +3164,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3272,23 +3272,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3385,32 +3385,32 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET Do V"), nil)
+				return NewResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -3424,20 +3424,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3449,20 +3449,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3688,9 +3688,9 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3754,23 +3754,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3862,23 +3862,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3975,18 +3975,18 @@ func TestClusterClient_SendPrimaryNodeOnlyButOneSlotAssigned(t *testing.T) {
 				return singleSlotResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -4042,7 +4042,7 @@ func TestClusterClientErr(t *testing.T) {
 					atomic.AddInt64(&count, 1)
 					return slotsResp
 				}
-				return newErrResult(v)
+				return NewErrResult(v)
 			},
 			DoStreamFn: func(cmd Completed) ValkeyResultStream {
 				return ValkeyResultStream{e: v}
@@ -4050,7 +4050,7 @@ func TestClusterClientErr(t *testing.T) {
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				res := make([]ValkeyResult, len(multi))
 				for i := range res {
-					res[i] = newErrResult(v)
+					res[i] = NewErrResult(v)
 				}
 				return &valkeyresults{s: res}
 			},
@@ -4058,12 +4058,12 @@ func TestClusterClientErr(t *testing.T) {
 				return MultiValkeyResultStream{e: v}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newErrResult(v)
+				return NewErrResult(v)
 			},
 			DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 				res := make([]ValkeyResult, len(multi))
 				for i := range res {
-					res[i] = newErrResult(v)
+					res[i] = NewErrResult(v)
 				}
 				return &valkeyresults{s: res}
 			},
@@ -4113,7 +4113,7 @@ func TestClusterClientErr(t *testing.T) {
 				if atomic.AddInt64(&first, 1) == 1 {
 					return singleSlotResp
 				}
-				return newErrResult(v)
+				return NewErrResult(v)
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return v
@@ -4257,9 +4257,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "MOVED 0 :0"), nil)
+						return NewResult(strmsg('-', "MOVED 0 :0"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4285,9 +4285,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "MOVED 0 :1"), nil)
+						return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4313,10 +4313,10 @@ func TestClusterClientErr(t *testing.T) {
 
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(strmsg('-', "MOVED 0 :2"), nil)
+							return NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -4348,12 +4348,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -4383,13 +4383,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+								ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -4423,31 +4423,31 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4521,33 +4521,33 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4621,29 +4621,29 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4714,32 +4714,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4810,32 +4810,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4909,35 +4909,35 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -5011,17 +5011,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -5076,17 +5076,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -5141,11 +5141,11 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					}
 					return nil
@@ -5192,12 +5192,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5229,12 +5229,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
+							ret[i] = NewResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5266,9 +5266,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "MOVED 0 :2"), nil)
+						return NewResult(strmsg('-', "MOVED 0 :2"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5298,12 +5298,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5335,12 +5335,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5375,12 +5375,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
+							ret[i] = NewResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5410,9 +5410,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(strmsg('-', "MOVED 0 :1"), nil)
+							return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5438,10 +5438,10 @@ func TestClusterClientErr(t *testing.T) {
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(strmsg('-', "MOVED 0 :2"), nil)
+							return NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5473,12 +5473,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5508,13 +5508,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+								ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5548,12 +5548,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5584,13 +5584,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 							return slotsMultiResp
 						}
-						return newResult(strmsg('-', "ASK 0 :1"), nil)
+						return NewResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, newResult(strmsg('+', "b"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, NewResult(strmsg('+', "b"), nil)}}
 					},
 				}
 			},
@@ -5617,13 +5617,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]ValkeyResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+								ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(strmsg('+', "OK"), nil)
-							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', "OK"), nil)
+							ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5652,13 +5652,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]ValkeyResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+								ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(strmsg('+', "OK"), nil)
-							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', "OK"), nil)
+							ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5690,13 +5690,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-						return newResult(strmsg('-', "ASK 0 :1"), nil)
+						return NewResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5720,13 +5720,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5750,18 +5750,18 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
 							return &valkeyresults{s: []ValkeyResult{
-								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
-								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil),
 							}}
 						}
 						return &valkeyresults{s: []ValkeyResult{
-							{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[4].Commands()[1])}), nil),
-							{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[10].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[4].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[10].Commands()[1])}), nil),
 						}}
 					},
 				}
@@ -5792,9 +5792,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "TRYAGAIN"), nil)
+						return NewResult(strmsg('-', "TRYAGAIN"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5816,10 +5816,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]ValkeyResult, len(multi))
-					ret[0] = newResult(strmsg('+', "b"), nil)
+					ret[0] = NewResult(strmsg('+', "b"), nil)
 					return &valkeyresults{s: ret}
 				}}
 			},
@@ -5842,10 +5842,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]ValkeyResult, len(multi))
-					ret[0] = newResult(strmsg('+', multi[0].Commands()[1]), nil)
+					ret[0] = NewResult(strmsg('+', multi[0].Commands()[1]), nil)
 					return &valkeyresults{s: ret}
 				}}
 			},
@@ -5876,9 +5876,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(strmsg('-', "TRYAGAIN"), nil)
+							return NewResult(strmsg('-', "TRYAGAIN"), nil)
 						}
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5901,9 +5901,9 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "b"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "b"), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5928,9 +5928,9 @@ func TestClusterClientErr(t *testing.T) {
 					return shardsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', multi[0].Cmd.Commands()[1]), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', multi[0].Cmd.Commands()[1]), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -6509,9 +6509,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -6531,9 +6531,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "ERR some other error"), nil)
+				return NewResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -6550,9 +6550,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -6571,9 +6571,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6588,9 +6588,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6612,9 +6612,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -6635,9 +6635,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -6687,9 +6687,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6713,18 +6713,18 @@ func TestClusterClientMovedRetry(t *testing.T) {
 			for i, cmd := range multi {
 				cmdName := cmd.Commands()[0]
 				if cmdName == "MULTI" {
-					results[i] = newResult(strmsg('+', "OK"), nil)
+					results[i] = NewResult(strmsg('+', "OK"), nil)
 				} else if cmdName == "EXEC" {
 					if attempts == 1 {
 						// return MOVED error only for EXEC on first attempt
 						// making sure we do not panic on wslots connection reassignment because EXEC's "slot" is 16384 (InitSlot)
-						results[i] = newResult(strmsg('-', "MOVED 1 127.0.0.1"), nil)
+						results[i] = NewResult(strmsg('-', "MOVED 1 127.0.0.1"), nil)
 					} else {
 						// return a successful transaction result for the retry
-						results[i] = newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "some_value")}), nil)
+						results[i] = NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "some_value")}), nil)
 					}
 				} else {
-					results[i] = newResult(strmsg('+', "QUEUED"), nil)
+					results[i] = NewResult(strmsg('+', "QUEUED"), nil)
 				}
 			}
 			return &valkeyresults{s: results}
@@ -6757,9 +6757,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 127.0.0.1"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 127.0.0.1"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6783,7 +6783,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Always return MOVED to simulate infinite redirect loop
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6819,7 +6819,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				// Always return MOVED to simulate infinite redirect loop
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6855,7 +6855,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Always return MOVED to simulate infinite redirect loop
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
 			},
 		}
 		client, err := newClusterClient(
@@ -6894,7 +6894,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 				// Always return MOVED to simulate infinite redirect loop
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
 			},
 		}
 		client, err := newClusterClient(
@@ -6933,9 +6933,9 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				attempts++
 				// Return MOVED twice, then success
 				if attempts <= 2 {
-					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6972,9 +6972,9 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				attempts++
 				// Return MOVED 10 times, then success
 				if attempts <= 10 {
-					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -7015,7 +7015,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				movedCount++
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7062,7 +7062,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Always return MOVED
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7109,14 +7109,14 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				if loopCount == 1 {
 					results := make([]ValkeyResult, len(multi))
 					for i := range results {
-						results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+						results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 					}
 					return &valkeyresults{s: results}
 				}
 				// Second loop: return success
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('+', "OK"), nil)
+					results[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7161,7 +7161,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Always return MOVED
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7203,7 +7203,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Always return MOVED
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -7236,13 +7236,13 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Return ASK error
-				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Return OK for ASKING, and ASK error for the command to simulate infinite loop
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil),
 				}}
 			},
 		}
@@ -7279,7 +7279,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				// Return ASK error
-				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// DoCache with ASK uses askingMultiCache which uses DoMulti
@@ -7293,7 +7293,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 
 				return &valkeyresults{s: []ValkeyResult{
 					{}, {}, {}, {}, {}, // First 5 results (ignored/checked for errors)
-					newResult(slicemsg('*', execResp), nil), // EXEC result
+					NewResult(slicemsg('*', execResp), nil), // EXEC result
 				}}
 			},
 		}
@@ -7343,8 +7343,8 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					// We need to return [OK, ASK] for each command pair (ASKING, CMD)
 					results := make([]ValkeyResult, len(multi))
 					for i := 0; i < len(multi); i += 2 {
-						results[i] = newResult(strmsg('+', "OK"), nil)                     // ASKING
-						results[i+1] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil) // CMD
+						results[i] = NewResult(strmsg('+', "OK"), nil)                     // ASKING
+						results[i+1] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil) // CMD
 					}
 					return &valkeyresults{s: results}
 				}
@@ -7352,7 +7352,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Initial call (no ASKING)
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7395,7 +7395,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Return ASK error
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7404,18 +7404,18 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				results := make([]ValkeyResult, len(multi))
 				for i := 0; i < len(multi); i += 6 {
 					// Fill dummies for first 5
-					results[i] = newResult(strmsg('+', "OK"), nil)
-					results[i+1] = newResult(strmsg('+', "OK"), nil)
-					results[i+2] = newResult(strmsg('+', "OK"), nil)
-					results[i+3] = newResult(strmsg('+', "OK"), nil)
-					results[i+4] = newResult(strmsg('+', "OK"), nil)
+					results[i] = NewResult(strmsg('+', "OK"), nil)
+					results[i+1] = NewResult(strmsg('+', "OK"), nil)
+					results[i+2] = NewResult(strmsg('+', "OK"), nil)
+					results[i+3] = NewResult(strmsg('+', "OK"), nil)
+					results[i+4] = NewResult(strmsg('+', "OK"), nil)
 
 					// EXEC result at index 5
 					execResp := []ValkeyMessage{
 						strmsg('+', "OK"),                   // PTTL result
 						strmsg('-', "ASK 0 127.0.0.1:7001"), // CMD result (ASK)
 					}
-					results[i+5] = newResult(slicemsg('*', execResp), nil)
+					results[i+5] = NewResult(slicemsg('*', execResp), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7459,16 +7459,16 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// 3. (DoMulti handles this step, returning MOVED)
 				// 4. ASK (Limit reached)
 				if attempts == 1 {
-					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Used when ASK is handled
 				// Return OK for ASKING, and MOVED for the command
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil),
 				}}
 			},
 		}
@@ -7523,14 +7523,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		attempts := 0
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(ValkeyMessage{typ: '_'}, nil)}}
+				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :0"), nil), NewResult(ValkeyMessage{typ: '_'}, nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7546,14 +7546,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 
 		attempts := 0
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :0"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(ValkeyMessage{typ: '_'}, nil)}}
+				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :0"), nil), NewResult(ValkeyMessage{typ: '_'}, nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -7568,7 +7568,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		askDone := false
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
@@ -7579,7 +7579,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 				t.Errorf("expected 3 cmds on ASK wire under .ToStaticTTL(), got %d", len(multi))
 			}
 			// Reply at offset 2 is the cmd reply directly (no EXEC unwrap).
-			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7594,14 +7594,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		askDone := false
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :0"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
 			if len(multi) != 3 {
 				t.Errorf("expected 3 cmds on ASK wire under .ToStaticTTL() (1 key × stride 3), got %d", len(multi))
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -7617,7 +7617,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		askDone := false
 		errInjected := false
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
@@ -7628,14 +7628,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 				errInjected = true
 				return &valkeyresults{s: []ValkeyResult{
 					{}, {},
-					newErrResult(errors.New("transport: connection closed")),
+					NewErrResult(errors.New("transport: connection closed")),
 				}}
 			}
 			// shouldRefreshRetry treats non-ValkeyError as RedirectRetry, so
 			// the cluster client loops back through pick → DoCache → ASK →
 			// askingMultiCache. On the second pass, succeed so the test
 			// terminates instead of retrying forever.
-			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7653,13 +7653,13 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:0"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:0"), nil)
 			}
 			// Second call runs on the new owner (ncc.DoCache); cluster
 			// passes the original Cacheable, so the static-TTL tag must
 			// still be set on the retry.
 			taggedOnRetry = cmds.IsStaticTTL(Completed(cmd))
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7688,7 +7688,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 			// Force ASK on both keys so askingMultiCache runs with the mixed batch.
 			rs := make([]ValkeyResult, len(multi))
 			for i := range multi {
-				rs[i] = newResult(strmsg('-', "ASK 0 :0"), nil)
+				rs[i] = NewResult(strmsg('-', "ASK 0 :0"), nil)
 			}
 			return &valkeyresults{s: rs}
 		}
@@ -7705,12 +7705,12 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 			for i := range multi {
 				switch (i + 1) % 6 {
 				case 0: // EXEC reply
-					rs[i] = newResult(slicemsg('*', []ValkeyMessage{
+					rs[i] = NewResult(slicemsg('*', []ValkeyMessage{
 						{typ: ':', intlen: 10000},
 						strmsg('$', "v"),
 					}), nil)
 				default:
-					rs[i] = newResult(strmsg('+', "OK"), nil)
+					rs[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 			}
 			return &valkeyresults{s: rs}
@@ -7739,32 +7739,32 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET Do V"), nil)
+				return NewResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -7778,20 +7778,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -7803,20 +7803,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -8045,9 +8045,9 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -8107,23 +8107,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8215,23 +8215,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8328,40 +8328,40 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -8546,9 +8546,9 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -8609,23 +8609,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8717,23 +8717,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8829,7 +8829,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 					return slotsMultiResp
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -8851,9 +8851,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return slotsMultiResp
 			}
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8870,11 +8870,11 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			}
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
-				return newResult(strmsg('-', "MOVED 0 :1"), nil)
+				return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
-				return newErrResult(errConnExpired)
+				return NewErrResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8889,13 +8889,13 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 				return slotsMultiResp
 			}
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewResult(strmsg('+', "OK"), nil)}}
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8912,9 +8912,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return slotsMultiResp
 			}
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8931,11 +8931,11 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			}
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
-				return newResult(strmsg('-', "MOVED 0 :1"), nil)
+				return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
-				return newErrResult(errConnExpired)
+				return NewErrResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8947,13 +8947,13 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{{}, NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "OK")}), nil)}}
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8966,9 +8966,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8981,10 +8981,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -9008,54 +9008,54 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "1"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newErrResult(errConnExpired),
+					NewErrResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -9098,15 +9098,15 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
 				for i := range ret {
-					ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+					ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 				}
 				return &valkeyresults{s: ret}
 			case 2:
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			}
 			for i := 0; i < len(multi); i += 2 {
-				ret[i] = newResult(strmsg('+', "OK"), nil)
-				ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+				ret[i] = NewResult(strmsg('+', "OK"), nil)
+				ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 			}
 			return &valkeyresults{s: ret}
 		}
@@ -9138,73 +9138,73 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				ret := make([]ValkeyResult, len(multi))
 				for i := range ret {
 					if isMulti(multi[i]) || isExec(multi[i]) {
-						ret[i] = newResult(strmsg('+', "OK"), nil)
+						ret[i] = NewResult(strmsg('+', "OK"), nil)
 						continue
 					}
-					ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+					ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 				}
 				return &valkeyresults{s: ret}
 			case 2: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			case 3: // errConnExpired at Asking command before Multi command
 				if len(multi) != 9 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "1"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Multi command
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Asking command before Multi command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 5: // errConnExpired in the middle of transaction block
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 6: // errConnExpired at Exec Command
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 7: // errConnExpired at end of processing
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newResult(strmsg('+', "OK"), nil),
-					newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewErrResult(errConnExpired),
 				}}
 			case 8:
 				if len(multi) != 2 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[7].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -9243,10 +9243,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -9258,10 +9258,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {
@@ -9299,14 +9299,14 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -9315,13 +9315,13 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 	}
@@ -9329,31 +9329,31 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -9440,40 +9440,40 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -9658,9 +9658,9 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -9721,23 +9721,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -9829,23 +9829,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -9941,40 +9941,40 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -10159,9 +10159,9 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -10222,23 +10222,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10330,23 +10330,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10442,32 +10442,32 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET Do V"), nil)
+				return NewResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -10481,20 +10481,20 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -10506,20 +10506,20 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -10748,9 +10748,9 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -10810,23 +10810,23 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10918,23 +10918,23 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -11028,14 +11028,14 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -11044,13 +11044,13 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 	}
@@ -11058,31 +11058,31 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -11168,7 +11168,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_Do(t *testing.T) {
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11177,7 +11177,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_Do(t *testing.T) {
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET K1{d}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{d}"), nil)
+				return NewResult(strmsg('+', "GET K1{d}"), nil)
 			},
 		},
 	}
@@ -11219,7 +11219,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMulti(t *testing.T) {
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11229,7 +11229,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMulti(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -11274,7 +11274,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11284,7 +11284,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/valkey-io/valkey-go/internal/cmds"
 )
 
-var slotsResp = NewResult(slicemsg('*', []ValkeyMessage{
+var slotsResp = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 16383},
@@ -35,7 +35,7 @@ var slotsResp = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -66,7 +66,7 @@ var slotsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiRespWithoutReplicas = NewResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -87,7 +87,7 @@ var slotsMultiRespWithoutReplicas = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiRespWithMultiReplicas = NewResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -138,7 +138,7 @@ var slotsMultiRespWithMultiReplicas = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotResp = NewResult(slicemsg('*', []ValkeyMessage{
+var singleSlotResp = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -150,7 +150,7 @@ var singleSlotResp = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotResp2 = NewResult(slicemsg('*', []ValkeyMessage{
+var singleSlotResp2 = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -162,7 +162,7 @@ var singleSlotResp2 = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotWithoutIP = NewResult(slicemsg('*', []ValkeyMessage{
+var singleSlotWithoutIP = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -188,7 +188,7 @@ var singleSlotWithoutIP = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsResp = NewResult(slicemsg(typeArray, []ValkeyMessage{
+var shardsResp = newResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -267,7 +267,7 @@ var shardsResp = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsRespTls = NewResult(slicemsg(typeArray, []ValkeyMessage{
+var shardsRespTls = newResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -374,7 +374,7 @@ var shardsRespTls = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
+var shardsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -529,7 +529,7 @@ var shardsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleShardResp2 = NewResult(slicemsg('*', []ValkeyMessage{
+var singleShardResp2 = newResult(slicemsg('*', []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -586,7 +586,7 @@ var singleShardResp2 = NewResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleShardWithoutIP = NewResult(slicemsg(typeArray, []ValkeyMessage{
+var singleShardWithoutIP = newResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -751,7 +751,7 @@ func TestClusterClientInit(t *testing.T) {
 		if _, err := newClusterClient(
 			&ClientOption{InitAddress: []string{":0"}},
 			func(dst string, opt *ClientOption) conn {
-				return &mockConn{DoFn: func(cmd Completed) ValkeyResult { return NewErrResult(v) }}
+				return &mockConn{DoFn: func(cmd Completed) ValkeyResult { return newErrResult(v) }}
 			},
 			newRetryer(defaultRetryDelayFn),
 		); err != v {
@@ -767,7 +767,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
+							return newResult(slicemsg('*', []ValkeyMessage{}), nil)
 						}
 						return slotsResp
 					},
@@ -787,7 +787,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
+							return newResult(slicemsg('*', []ValkeyMessage{}), nil)
 						}
 						return shardsResp
 					},
@@ -851,7 +851,7 @@ func TestClusterClientInit(t *testing.T) {
 			behavior[addr] = fn
 		}
 		emptyResp := func() ValkeyResult {
-			return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
+			return newResult(slicemsg('*', []ValkeyMessage{}), nil)
 		}
 
 		resetCalls()
@@ -886,7 +886,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
-						return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
+						return newResult(slicemsg('*', []ValkeyMessage{}), nil)
 					},
 				}
 			},
@@ -902,7 +902,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
-						return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
+						return newResult(slicemsg('*', []ValkeyMessage{}), nil)
 					},
 					VersionFn: func() int { return 8 },
 				}
@@ -1734,7 +1734,7 @@ func TestClusterClient(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -1744,21 +1744,21 @@ func TestClusterClient(t *testing.T) {
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Do"), nil)
+				return newResult(strmsg('+', "Do"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Info"), nil)
+				return newResult(strmsg('+', "Info"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "DoCache"), nil)
+				return newResult(strmsg('+', "DoCache"), nil)
 			},
 		},
 	}
@@ -2009,9 +2009,9 @@ func TestClusterClient(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2072,23 +2072,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2180,23 +2180,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2394,40 +2394,40 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -2609,9 +2609,9 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2672,23 +2672,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2780,23 +2780,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2893,10 +2893,10 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 		},
 	}
@@ -2904,31 +2904,31 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -3098,9 +3098,9 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3164,23 +3164,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3272,23 +3272,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3385,32 +3385,32 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "SET Do V"), nil)
+				return newResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
+					resps[i] = newResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
+					resps[i] = newResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -3424,20 +3424,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3449,20 +3449,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3688,9 +3688,9 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3754,23 +3754,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3862,23 +3862,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3975,18 +3975,18 @@ func TestClusterClient_SendPrimaryNodeOnlyButOneSlotAssigned(t *testing.T) {
 				return singleSlotResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
+					resps[i] = newResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
+					resps[i] = newResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -4042,7 +4042,7 @@ func TestClusterClientErr(t *testing.T) {
 					atomic.AddInt64(&count, 1)
 					return slotsResp
 				}
-				return NewErrResult(v)
+				return newErrResult(v)
 			},
 			DoStreamFn: func(cmd Completed) ValkeyResultStream {
 				return ValkeyResultStream{e: v}
@@ -4050,7 +4050,7 @@ func TestClusterClientErr(t *testing.T) {
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				res := make([]ValkeyResult, len(multi))
 				for i := range res {
-					res[i] = NewErrResult(v)
+					res[i] = newErrResult(v)
 				}
 				return &valkeyresults{s: res}
 			},
@@ -4058,12 +4058,12 @@ func TestClusterClientErr(t *testing.T) {
 				return MultiValkeyResultStream{e: v}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewErrResult(v)
+				return newErrResult(v)
 			},
 			DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 				res := make([]ValkeyResult, len(multi))
 				for i := range res {
-					res[i] = NewErrResult(v)
+					res[i] = newErrResult(v)
 				}
 				return &valkeyresults{s: res}
 			},
@@ -4113,7 +4113,7 @@ func TestClusterClientErr(t *testing.T) {
 				if atomic.AddInt64(&first, 1) == 1 {
 					return singleSlotResp
 				}
-				return NewErrResult(v)
+				return newErrResult(v)
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return v
@@ -4257,9 +4257,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return NewResult(strmsg('-', "MOVED 0 :0"), nil)
+						return newResult(strmsg('-', "MOVED 0 :0"), nil)
 					}
-					return NewResult(strmsg('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4285,9 +4285,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return NewResult(strmsg('-', "MOVED 0 :1"), nil)
+						return newResult(strmsg('-', "MOVED 0 :1"), nil)
 					}
-					return NewResult(strmsg('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4313,10 +4313,10 @@ func TestClusterClientErr(t *testing.T) {
 
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return NewResult(strmsg('-', "MOVED 0 :2"), nil)
+							return newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return NewResult(strmsg('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -4348,12 +4348,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -4383,13 +4383,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
+								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -4423,31 +4423,31 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('+', "4"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4521,33 +4521,33 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('+', "4"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4621,29 +4621,29 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "4"), nil),
-							NewResult(strmsg('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4714,32 +4714,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "4"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "7"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4810,32 +4810,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							NewResult(strmsg('+', "4"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4909,35 +4909,35 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('-', "ASK 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "4"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(strmsg('+', "QUEUED"), nil),
-							NewResult(slicemsg('*', []ValkeyMessage{
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -5011,17 +5011,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -5076,17 +5076,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "EXECABORT"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -5141,11 +5141,11 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							NewResult(strmsg('+', "1"), nil),
-							NewResult(strmsg('+', "OK"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
-							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					}
 					return nil
@@ -5192,12 +5192,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5229,12 +5229,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "TRYAGAIN"), nil)
+							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5266,9 +5266,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return NewResult(strmsg('-', "MOVED 0 :2"), nil)
+						return newResult(strmsg('-', "MOVED 0 :2"), nil)
 					}
-					return NewResult(strmsg('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5298,12 +5298,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5335,12 +5335,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5375,12 +5375,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "TRYAGAIN"), nil)
+							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5410,9 +5410,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return NewResult(strmsg('-', "MOVED 0 :1"), nil)
+							return newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
-						return NewResult(strmsg('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5438,10 +5438,10 @@ func TestClusterClientErr(t *testing.T) {
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return NewResult(strmsg('-', "MOVED 0 :2"), nil)
+							return newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return NewResult(strmsg('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5473,12 +5473,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5508,13 +5508,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
+								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5548,12 +5548,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5584,13 +5584,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 							return slotsMultiResp
 						}
-						return NewResult(strmsg('-', "ASK 0 :1"), nil)
+						return newResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, NewResult(strmsg('+', "b"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, newResult(strmsg('+', "b"), nil)}}
 					},
 				}
 			},
@@ -5617,13 +5617,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]ValkeyResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
+								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = NewResult(strmsg('+', "OK"), nil)
-							ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', "OK"), nil)
+							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5652,13 +5652,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]ValkeyResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
+								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = NewResult(strmsg('+', "OK"), nil)
-							ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', "OK"), nil)
+							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5690,13 +5690,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-						return NewResult(strmsg('-', "ASK 0 :1"), nil)
+						return newResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5720,13 +5720,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :1"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5750,18 +5750,18 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :1"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
 							return &valkeyresults{s: []ValkeyResult{
-								{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil),
-								{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
 							}}
 						}
 						return &valkeyresults{s: []ValkeyResult{
-							{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[4].Commands()[1])}), nil),
-							{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[10].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[4].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[10].Commands()[1])}), nil),
 						}}
 					},
 				}
@@ -5792,9 +5792,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return NewResult(strmsg('-', "TRYAGAIN"), nil)
+						return newResult(strmsg('-', "TRYAGAIN"), nil)
 					}
-					return NewResult(strmsg('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5816,10 +5816,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]ValkeyResult, len(multi))
-					ret[0] = NewResult(strmsg('+', "b"), nil)
+					ret[0] = newResult(strmsg('+', "b"), nil)
 					return &valkeyresults{s: ret}
 				}}
 			},
@@ -5842,10 +5842,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]ValkeyResult, len(multi))
-					ret[0] = NewResult(strmsg('+', multi[0].Commands()[1]), nil)
+					ret[0] = newResult(strmsg('+', multi[0].Commands()[1]), nil)
 					return &valkeyresults{s: ret}
 				}}
 			},
@@ -5876,9 +5876,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return NewResult(strmsg('-', "TRYAGAIN"), nil)
+							return newResult(strmsg('-', "TRYAGAIN"), nil)
 						}
-						return NewResult(strmsg('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5901,9 +5901,9 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "b"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "b"), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5928,9 +5928,9 @@ func TestClusterClientErr(t *testing.T) {
 					return shardsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', multi[0].Cmd.Commands()[1]), nil)}}
+					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', multi[0].Cmd.Commands()[1]), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -6509,9 +6509,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -6531,9 +6531,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "ERR some other error"), nil)
+				return newResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -6550,9 +6550,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -6571,9 +6571,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6588,9 +6588,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6612,9 +6612,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -6635,9 +6635,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -6687,9 +6687,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6713,18 +6713,18 @@ func TestClusterClientMovedRetry(t *testing.T) {
 			for i, cmd := range multi {
 				cmdName := cmd.Commands()[0]
 				if cmdName == "MULTI" {
-					results[i] = NewResult(strmsg('+', "OK"), nil)
+					results[i] = newResult(strmsg('+', "OK"), nil)
 				} else if cmdName == "EXEC" {
 					if attempts == 1 {
 						// return MOVED error only for EXEC on first attempt
 						// making sure we do not panic on wslots connection reassignment because EXEC's "slot" is 16384 (InitSlot)
-						results[i] = NewResult(strmsg('-', "MOVED 1 127.0.0.1"), nil)
+						results[i] = newResult(strmsg('-', "MOVED 1 127.0.0.1"), nil)
 					} else {
 						// return a successful transaction result for the retry
-						results[i] = NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "some_value")}), nil)
+						results[i] = newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "some_value")}), nil)
 					}
 				} else {
-					results[i] = NewResult(strmsg('+', "QUEUED"), nil)
+					results[i] = newResult(strmsg('+', "QUEUED"), nil)
 				}
 			}
 			return &valkeyresults{s: results}
@@ -6757,9 +6757,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 127.0.0.1"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 127.0.0.1"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6783,7 +6783,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Always return MOVED to simulate infinite redirect loop
-				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6819,7 +6819,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				// Always return MOVED to simulate infinite redirect loop
-				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6855,7 +6855,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Always return MOVED to simulate infinite redirect loop
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
 			},
 		}
 		client, err := newClusterClient(
@@ -6894,7 +6894,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 				// Always return MOVED to simulate infinite redirect loop
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
 			},
 		}
 		client, err := newClusterClient(
@@ -6933,9 +6933,9 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				attempts++
 				// Return MOVED twice, then success
 				if attempts <= 2 {
-					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6972,9 +6972,9 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				attempts++
 				// Return MOVED 10 times, then success
 				if attempts <= 10 {
-					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -7015,7 +7015,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				movedCount++
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7062,7 +7062,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Always return MOVED
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7109,14 +7109,14 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				if loopCount == 1 {
 					results := make([]ValkeyResult, len(multi))
 					for i := range results {
-						results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+						results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 					}
 					return &valkeyresults{s: results}
 				}
 				// Second loop: return success
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = NewResult(strmsg('+', "OK"), nil)
+					results[i] = newResult(strmsg('+', "OK"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7161,7 +7161,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Always return MOVED
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7203,7 +7203,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Always return MOVED
-				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -7236,13 +7236,13 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Return ASK error
-				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Return OK for ASKING, and ASK error for the command to simulate infinite loop
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil),
 				}}
 			},
 		}
@@ -7279,7 +7279,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				// Return ASK error
-				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// DoCache with ASK uses askingMultiCache which uses DoMulti
@@ -7293,7 +7293,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 
 				return &valkeyresults{s: []ValkeyResult{
 					{}, {}, {}, {}, {}, // First 5 results (ignored/checked for errors)
-					NewResult(slicemsg('*', execResp), nil), // EXEC result
+					newResult(slicemsg('*', execResp), nil), // EXEC result
 				}}
 			},
 		}
@@ -7343,8 +7343,8 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					// We need to return [OK, ASK] for each command pair (ASKING, CMD)
 					results := make([]ValkeyResult, len(multi))
 					for i := 0; i < len(multi); i += 2 {
-						results[i] = NewResult(strmsg('+', "OK"), nil)                     // ASKING
-						results[i+1] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil) // CMD
+						results[i] = newResult(strmsg('+', "OK"), nil)                     // ASKING
+						results[i+1] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil) // CMD
 					}
 					return &valkeyresults{s: results}
 				}
@@ -7352,7 +7352,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Initial call (no ASKING)
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+					results[i] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7395,7 +7395,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Return ASK error
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+					results[i] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7404,18 +7404,18 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				results := make([]ValkeyResult, len(multi))
 				for i := 0; i < len(multi); i += 6 {
 					// Fill dummies for first 5
-					results[i] = NewResult(strmsg('+', "OK"), nil)
-					results[i+1] = NewResult(strmsg('+', "OK"), nil)
-					results[i+2] = NewResult(strmsg('+', "OK"), nil)
-					results[i+3] = NewResult(strmsg('+', "OK"), nil)
-					results[i+4] = NewResult(strmsg('+', "OK"), nil)
+					results[i] = newResult(strmsg('+', "OK"), nil)
+					results[i+1] = newResult(strmsg('+', "OK"), nil)
+					results[i+2] = newResult(strmsg('+', "OK"), nil)
+					results[i+3] = newResult(strmsg('+', "OK"), nil)
+					results[i+4] = newResult(strmsg('+', "OK"), nil)
 
 					// EXEC result at index 5
 					execResp := []ValkeyMessage{
 						strmsg('+', "OK"),                   // PTTL result
 						strmsg('-', "ASK 0 127.0.0.1:7001"), // CMD result (ASK)
 					}
-					results[i+5] = NewResult(slicemsg('*', execResp), nil)
+					results[i+5] = newResult(slicemsg('*', execResp), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7459,16 +7459,16 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// 3. (DoMulti handles this step, returning MOVED)
 				// 4. ASK (Limit reached)
 				if attempts == 1 {
-					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Used when ASK is handled
 				// Return OK for ASKING, and MOVED for the command
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil),
 				}}
 			},
 		}
@@ -7523,14 +7523,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		attempts := 0
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return NewResult(strmsg('-', "ASK 0 :0"), nil)
+			return newResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :0"), nil), NewResult(ValkeyMessage{typ: '_'}, nil)}}
+				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(ValkeyMessage{typ: '_'}, nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7546,14 +7546,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 
 		attempts := 0
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :0"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :0"), nil), NewResult(ValkeyMessage{typ: '_'}, nil)}}
+				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(ValkeyMessage{typ: '_'}, nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -7568,7 +7568,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		askDone := false
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return NewResult(strmsg('-', "ASK 0 :0"), nil)
+			return newResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
@@ -7579,7 +7579,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 				t.Errorf("expected 3 cmds on ASK wire under .ToStaticTTL(), got %d", len(multi))
 			}
 			// Reply at offset 2 is the cmd reply directly (no EXEC unwrap).
-			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7594,14 +7594,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		askDone := false
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :0"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
 			if len(multi) != 3 {
 				t.Errorf("expected 3 cmds on ASK wire under .ToStaticTTL() (1 key × stride 3), got %d", len(multi))
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -7617,7 +7617,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		askDone := false
 		errInjected := false
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return NewResult(strmsg('-', "ASK 0 :0"), nil)
+			return newResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
@@ -7628,14 +7628,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 				errInjected = true
 				return &valkeyresults{s: []ValkeyResult{
 					{}, {},
-					NewErrResult(errors.New("transport: connection closed")),
+					newErrResult(errors.New("transport: connection closed")),
 				}}
 			}
 			// shouldRefreshRetry treats non-ValkeyError as RedirectRetry, so
 			// the cluster client loops back through pick → DoCache → ASK →
 			// askingMultiCache. On the second pass, succeed so the test
 			// terminates instead of retrying forever.
-			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7653,13 +7653,13 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:0"), nil)
+				return newResult(strmsg('-', "MOVED 0 127.0.0.1:0"), nil)
 			}
 			// Second call runs on the new owner (ncc.DoCache); cluster
 			// passes the original Cacheable, so the static-TTL tag must
 			// still be set on the retry.
 			taggedOnRetry = cmds.IsStaticTTL(Completed(cmd))
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7688,7 +7688,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 			// Force ASK on both keys so askingMultiCache runs with the mixed batch.
 			rs := make([]ValkeyResult, len(multi))
 			for i := range multi {
-				rs[i] = NewResult(strmsg('-', "ASK 0 :0"), nil)
+				rs[i] = newResult(strmsg('-', "ASK 0 :0"), nil)
 			}
 			return &valkeyresults{s: rs}
 		}
@@ -7705,12 +7705,12 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 			for i := range multi {
 				switch (i + 1) % 6 {
 				case 0: // EXEC reply
-					rs[i] = NewResult(slicemsg('*', []ValkeyMessage{
+					rs[i] = newResult(slicemsg('*', []ValkeyMessage{
 						{typ: ':', intlen: 10000},
 						strmsg('$', "v"),
 					}), nil)
 				default:
-					rs[i] = NewResult(strmsg('+', "OK"), nil)
+					rs[i] = newResult(strmsg('+', "OK"), nil)
 				}
 			}
 			return &valkeyresults{s: rs}
@@ -7739,32 +7739,32 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "SET Do V"), nil)
+				return newResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
+					resps[i] = newResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
+					resps[i] = newResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -7778,20 +7778,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -7803,20 +7803,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -8045,9 +8045,9 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -8107,23 +8107,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8215,23 +8215,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8328,40 +8328,40 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -8546,9 +8546,9 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -8609,23 +8609,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8717,23 +8717,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8829,7 +8829,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 					return slotsMultiResp
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -8851,9 +8851,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return slotsMultiResp
 			}
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return NewErrResult(errConnExpired)
+				return newErrResult(errConnExpired)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8870,11 +8870,11 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			}
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
-				return NewResult(strmsg('-', "MOVED 0 :1"), nil)
+				return newResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
-				return NewErrResult(errConnExpired)
+				return newErrResult(errConnExpired)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8889,13 +8889,13 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 				return slotsMultiResp
 			}
-			return NewResult(strmsg('-', "ASK 0 :0"), nil)
+			return newResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8912,9 +8912,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return slotsMultiResp
 			}
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return NewErrResult(errConnExpired)
+				return newErrResult(errConnExpired)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8931,11 +8931,11 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			}
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
-				return NewResult(strmsg('-', "MOVED 0 :1"), nil)
+				return newResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
-				return NewErrResult(errConnExpired)
+				return newErrResult(errConnExpired)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8947,13 +8947,13 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return NewResult(strmsg('-', "ASK 0 :0"), nil)
+			return newResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{{}, newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "OK")}), nil)}}
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8966,9 +8966,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8981,10 +8981,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -9008,54 +9008,54 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "1"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "1"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(slicemsg('*', []ValkeyMessage{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					NewErrResult(errConnExpired),
+					newErrResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -9098,15 +9098,15 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
 				for i := range ret {
-					ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
+					ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
 				}
 				return &valkeyresults{s: ret}
 			case 2:
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			}
 			for i := 0; i < len(multi); i += 2 {
-				ret[i] = NewResult(strmsg('+', "OK"), nil)
-				ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+				ret[i] = newResult(strmsg('+', "OK"), nil)
+				ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 			}
 			return &valkeyresults{s: ret}
 		}
@@ -9138,73 +9138,73 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				ret := make([]ValkeyResult, len(multi))
 				for i := range ret {
 					if isMulti(multi[i]) || isExec(multi[i]) {
-						ret[i] = NewResult(strmsg('+', "OK"), nil)
+						ret[i] = newResult(strmsg('+', "OK"), nil)
 						continue
 					}
-					ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
+					ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
 				}
 				return &valkeyresults{s: ret}
 			case 2: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			case 3: // errConnExpired at Asking command before Multi command
 				if len(multi) != 9 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "1"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "1"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Multi command
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Asking command before Multi command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 5: // errConnExpired in the middle of transaction block
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 6: // errConnExpired at Exec Command
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 7: // errConnExpired at end of processing
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(slicemsg('*', []ValkeyMessage{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					NewResult(strmsg('+', "OK"), nil),
-					NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newErrResult(errConnExpired),
 				}}
 			case 8:
 				if len(multi) != 2 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[7].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -9243,10 +9243,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -9258,10 +9258,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {
@@ -9299,14 +9299,14 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -9315,13 +9315,13 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{b}"), nil)
+				return newResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 	}
@@ -9329,31 +9329,31 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{b}"), nil)
+				return newResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -9440,40 +9440,40 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -9658,9 +9658,9 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -9721,23 +9721,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -9829,23 +9829,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -9941,40 +9941,40 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -10159,9 +10159,9 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -10222,23 +10222,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10330,23 +10330,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10442,32 +10442,32 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "SET Do V"), nil)
+				return newResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
+					resps[i] = newResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
+					resps[i] = newResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -10481,20 +10481,20 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -10506,20 +10506,20 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -10748,9 +10748,9 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -10810,23 +10810,23 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10918,23 +10918,23 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(strmsg('+', "OK"), nil),
-						NewResult(slicemsg('*', []ValkeyMessage{
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "Delegate0"), nil),
-					NewResult(strmsg('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -11028,14 +11028,14 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -11044,13 +11044,13 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{b}"), nil)
+				return newResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 	}
@@ -11058,31 +11058,31 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K2{b}"), nil)
+				return newResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return NewResult(strmsg('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -11168,7 +11168,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_Do(t *testing.T) {
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11177,7 +11177,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_Do(t *testing.T) {
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET K1{d}": func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "GET K1{d}"), nil)
+				return newResult(strmsg('+', "GET K1{d}"), nil)
 			},
 		},
 	}
@@ -11219,7 +11219,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMulti(t *testing.T) {
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11229,7 +11229,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMulti(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -11274,7 +11274,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11284,7 +11284,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -751,7 +751,7 @@ func TestClusterClientInit(t *testing.T) {
 		if _, err := newClusterClient(
 			&ClientOption{InitAddress: []string{":0"}},
 			func(dst string, opt *ClientOption) conn {
-				return &mockConn{DoFn: func(cmd Completed) ValkeyResult { return newErrResult(v) }}
+				return &mockConn{DoFn: func(cmd Completed) ValkeyResult { return NewErrorResult(v) }}
 			},
 			newRetryer(defaultRetryDelayFn),
 		); err != v {
@@ -4042,7 +4042,7 @@ func TestClusterClientErr(t *testing.T) {
 					atomic.AddInt64(&count, 1)
 					return slotsResp
 				}
-				return newErrResult(v)
+				return NewErrorResult(v)
 			},
 			DoStreamFn: func(cmd Completed) ValkeyResultStream {
 				return ValkeyResultStream{e: v}
@@ -4050,7 +4050,7 @@ func TestClusterClientErr(t *testing.T) {
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				res := make([]ValkeyResult, len(multi))
 				for i := range res {
-					res[i] = newErrResult(v)
+					res[i] = NewErrorResult(v)
 				}
 				return &valkeyresults{s: res}
 			},
@@ -4058,12 +4058,12 @@ func TestClusterClientErr(t *testing.T) {
 				return MultiValkeyResultStream{e: v}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newErrResult(v)
+				return NewErrorResult(v)
 			},
 			DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 				res := make([]ValkeyResult, len(multi))
 				for i := range res {
-					res[i] = newErrResult(v)
+					res[i] = NewErrorResult(v)
 				}
 				return &valkeyresults{s: res}
 			},
@@ -4113,7 +4113,7 @@ func TestClusterClientErr(t *testing.T) {
 				if atomic.AddInt64(&first, 1) == 1 {
 					return singleSlotResp
 				}
-				return newErrResult(v)
+				return NewErrorResult(v)
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return v
@@ -7628,7 +7628,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 				errInjected = true
 				return &valkeyresults{s: []ValkeyResult{
 					{}, {},
-					newErrResult(errors.New("transport: connection closed")),
+					NewErrorResult(errors.New("transport: connection closed")),
 				}}
 			}
 			// shouldRefreshRetry treats non-ValkeyError as RedirectRetry, so
@@ -8851,7 +8851,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return slotsMultiResp
 			}
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrorResult(errConnExpired)
 			}
 			return newResult(strmsg('+', "OK"), nil)
 		}
@@ -8872,7 +8872,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			case 1:
 				return newResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
-				return newErrResult(errConnExpired)
+				return NewErrorResult(errConnExpired)
 			}
 			return newResult(strmsg('+', "OK"), nil)
 		}
@@ -8893,7 +8893,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -8912,7 +8912,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return slotsMultiResp
 			}
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrorResult(errConnExpired)
 			}
 			return newResult(strmsg('+', "OK"), nil)
 		}
@@ -8933,7 +8933,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			case 1:
 				return newResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
-				return newErrResult(errConnExpired)
+				return NewErrorResult(errConnExpired)
 			}
 			return newResult(strmsg('+', "OK"), nil)
 		}
@@ -8951,7 +8951,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{{}, NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "OK")}), nil)}}
 		}
@@ -8966,7 +8966,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -8981,7 +8981,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
@@ -9008,14 +9008,14 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
@@ -9024,7 +9024,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
@@ -9034,7 +9034,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
@@ -9048,7 +9048,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
@@ -9102,7 +9102,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				}
 				return &valkeyresults{s: ret}
 			case 2:
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			}
 			for i := 0; i < len(multi); i += 2 {
 				ret[i] = newResult(strmsg('+', "OK"), nil)
@@ -9146,7 +9146,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return &valkeyresults{s: ret}
 			case 2: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 3: // errConnExpired at Asking command before Multi command
 				if len(multi) != 9 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
@@ -9154,7 +9154,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Multi command
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
@@ -9162,7 +9162,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				}
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "OK"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 5: // errConnExpired in the middle of transaction block
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
@@ -9172,7 +9172,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 6: // errConnExpired at Exec Command
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
@@ -9182,7 +9182,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 7: // errConnExpired at end of processing
 				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
@@ -9197,7 +9197,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 						strmsg('+', "3"),
 					}), nil),
 					newResult(strmsg('+', "OK"), nil),
-					newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired),
 				}}
 			case 8:
 				if len(multi) != 2 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[7].Commands()) {
@@ -9243,7 +9243,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
@@ -9258,7 +9258,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1729,7 +1729,7 @@ func TestClusterClient(t *testing.T) {
 			return ValkeyResult{}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{e: errors.New(cmd.Commands()[1])}
+			return NewErrorResultStream(errors.New(cmd.Commands()[1]))
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
@@ -4045,7 +4045,7 @@ func TestClusterClientErr(t *testing.T) {
 				return NewErrorResult(v)
 			},
 			DoStreamFn: func(cmd Completed) ValkeyResultStream {
-				return ValkeyResultStream{e: v}
+				return NewErrorResultStream(v)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				res := make([]ValkeyResult, len(multi))

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/valkey-io/valkey-go/internal/cmds"
 )
 
-var slotsResp = newResult(slicemsg('*', []ValkeyMessage{
+var slotsResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 16383},
@@ -35,7 +35,7 @@ var slotsResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -66,7 +66,7 @@ var slotsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiRespWithoutReplicas = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -87,7 +87,7 @@ var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []ValkeyMessage{
+var slotsMultiRespWithMultiReplicas = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 8192},
@@ -138,7 +138,7 @@ var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotResp = newResult(slicemsg('*', []ValkeyMessage{
+var singleSlotResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -150,7 +150,7 @@ var singleSlotResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotResp2 = newResult(slicemsg('*', []ValkeyMessage{
+var singleSlotResp2 = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -162,7 +162,7 @@ var singleSlotResp2 = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleSlotWithoutIP = newResult(slicemsg('*', []ValkeyMessage{
+var singleSlotWithoutIP = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg('*', []ValkeyMessage{
 		{typ: ':', intlen: 0},
 		{typ: ':', intlen: 0},
@@ -188,7 +188,7 @@ var singleSlotWithoutIP = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsResp = newResult(slicemsg(typeArray, []ValkeyMessage{
+var shardsResp = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -267,7 +267,7 @@ var shardsResp = newResult(slicemsg(typeArray, []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsRespTls = newResult(slicemsg(typeArray, []ValkeyMessage{
+var shardsRespTls = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -374,7 +374,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []ValkeyMessage{
 	}),
 }), nil)
 
-var shardsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
+var shardsMultiResp = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -529,7 +529,7 @@ var shardsMultiResp = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleShardResp2 = newResult(slicemsg('*', []ValkeyMessage{
+var singleShardResp2 = NewResult(slicemsg('*', []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -586,7 +586,7 @@ var singleShardResp2 = newResult(slicemsg('*', []ValkeyMessage{
 	}),
 }), nil)
 
-var singleShardWithoutIP = newResult(slicemsg(typeArray, []ValkeyMessage{
+var singleShardWithoutIP = NewResult(slicemsg(typeArray, []ValkeyMessage{
 	slicemsg(typeMap, []ValkeyMessage{
 		strmsg(typeBlobString, "slots"),
 		slicemsg(typeArray, []ValkeyMessage{
@@ -767,7 +767,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+							return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 						}
 						return slotsResp
 					},
@@ -787,7 +787,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+							return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 						}
 						return shardsResp
 					},
@@ -851,7 +851,7 @@ func TestClusterClientInit(t *testing.T) {
 			behavior[addr] = fn
 		}
 		emptyResp := func() ValkeyResult {
-			return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+			return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 		}
 
 		resetCalls()
@@ -886,7 +886,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
-						return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+						return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 					},
 				}
 			},
@@ -902,7 +902,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) ValkeyResult {
-						return newResult(slicemsg('*', []ValkeyMessage{}), nil)
+						return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
 					},
 					VersionFn: func() int { return 8 },
 				}
@@ -1734,7 +1734,7 @@ func TestClusterClient(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -1744,21 +1744,21 @@ func TestClusterClient(t *testing.T) {
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Do"), nil)
+				return NewResult(strmsg('+', "Do"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Info"), nil)
+				return NewResult(strmsg('+', "Info"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "DoCache"), nil)
+				return NewResult(strmsg('+', "DoCache"), nil)
 			},
 		},
 	}
@@ -2009,9 +2009,9 @@ func TestClusterClient(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2072,23 +2072,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2180,23 +2180,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2394,40 +2394,40 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -2609,9 +2609,9 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2672,23 +2672,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2780,23 +2780,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2893,10 +2893,10 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 		},
 	}
@@ -2904,31 +2904,31 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -3098,9 +3098,9 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3164,23 +3164,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3272,23 +3272,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3385,32 +3385,32 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET Do V"), nil)
+				return NewResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -3424,20 +3424,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3449,20 +3449,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3688,9 +3688,9 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3754,23 +3754,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3862,23 +3862,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3975,18 +3975,18 @@ func TestClusterClient_SendPrimaryNodeOnlyButOneSlotAssigned(t *testing.T) {
 				return singleSlotResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -4257,9 +4257,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "MOVED 0 :0"), nil)
+						return NewResult(strmsg('-', "MOVED 0 :0"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4285,9 +4285,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "MOVED 0 :1"), nil)
+						return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4313,10 +4313,10 @@ func TestClusterClientErr(t *testing.T) {
 
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(strmsg('-', "MOVED 0 :2"), nil)
+							return NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -4348,12 +4348,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -4383,13 +4383,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+								ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -4423,31 +4423,31 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4521,33 +4521,33 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4621,29 +4621,29 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4714,32 +4714,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4810,32 +4810,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -4909,35 +4909,35 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "ASK 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('+', "7"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "ASK 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "2"),
 								strmsg('+', "3"),
 							}), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "4"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(strmsg('+', "QUEUED"), nil),
-							newResult(slicemsg('*', []ValkeyMessage{
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(strmsg('+', "QUEUED"), nil),
+							NewResult(slicemsg('*', []ValkeyMessage{
 								strmsg('+', "5"),
 								strmsg('+', "6"),
 							}), nil),
@@ -5011,17 +5011,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -5076,17 +5076,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "EXECABORT"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "EXECABORT"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "4"), nil),
+							NewResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -5141,11 +5141,11 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &valkeyresults{s: []ValkeyResult{
-							newResult(strmsg('+', "1"), nil),
-							newResult(strmsg('+', "OK"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
-							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('+', "1"), nil),
+							NewResult(strmsg('+', "OK"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
+							NewResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							NewResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					}
 					return nil
@@ -5192,12 +5192,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5229,12 +5229,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
+							ret[i] = NewResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5266,9 +5266,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "MOVED 0 :2"), nil)
+						return NewResult(strmsg('-', "MOVED 0 :2"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5298,12 +5298,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5335,12 +5335,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5375,12 +5375,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
+							ret[i] = NewResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5410,9 +5410,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(strmsg('-', "MOVED 0 :1"), nil)
+							return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5438,10 +5438,10 @@ func TestClusterClientErr(t *testing.T) {
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(strmsg('-', "MOVED 0 :2"), nil)
+							return NewResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5473,12 +5473,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5508,13 +5508,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
+								ret[i] = NewResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5548,12 +5548,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]ValkeyResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
+							ret[i] = NewResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &valkeyresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = NewResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &valkeyresults{s: ret}
 				}}
@@ -5584,13 +5584,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 							return slotsMultiResp
 						}
-						return newResult(strmsg('-', "ASK 0 :1"), nil)
+						return NewResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, newResult(strmsg('+', "b"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, NewResult(strmsg('+', "b"), nil)}}
 					},
 				}
 			},
@@ -5617,13 +5617,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]ValkeyResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+								ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(strmsg('+', "OK"), nil)
-							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', "OK"), nil)
+							ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5652,13 +5652,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]ValkeyResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+								ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &valkeyresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(strmsg('+', "OK"), nil)
-							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = NewResult(strmsg('+', "OK"), nil)
+							ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &valkeyresults{s: ret}
 					},
@@ -5690,13 +5690,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-						return newResult(strmsg('-', "ASK 0 :1"), nil)
+						return NewResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5720,13 +5720,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
+							return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
+						return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5750,18 +5750,18 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *valkeyresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
 							return &valkeyresults{s: []ValkeyResult{
-								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
-								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :1"), nil),
 							}}
 						}
 						return &valkeyresults{s: []ValkeyResult{
-							{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[4].Commands()[1])}), nil),
-							{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[10].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[4].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, strmsg('+', multi[10].Commands()[1])}), nil),
 						}}
 					},
 				}
@@ -5792,9 +5792,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(strmsg('-', "TRYAGAIN"), nil)
+						return NewResult(strmsg('-', "TRYAGAIN"), nil)
 					}
-					return newResult(strmsg('+', "b"), nil)
+					return NewResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5816,10 +5816,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]ValkeyResult, len(multi))
-					ret[0] = newResult(strmsg('+', "b"), nil)
+					ret[0] = NewResult(strmsg('+', "b"), nil)
 					return &valkeyresults{s: ret}
 				}}
 			},
@@ -5842,10 +5842,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]ValkeyResult, len(multi))
-					ret[0] = newResult(strmsg('+', multi[0].Commands()[1]), nil)
+					ret[0] = NewResult(strmsg('+', multi[0].Commands()[1]), nil)
 					return &valkeyresults{s: ret}
 				}}
 			},
@@ -5876,9 +5876,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(strmsg('-', "TRYAGAIN"), nil)
+							return NewResult(strmsg('-', "TRYAGAIN"), nil)
 						}
-						return newResult(strmsg('+', "b"), nil)
+						return NewResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5901,9 +5901,9 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "b"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "b"), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5928,9 +5928,9 @@ func TestClusterClientErr(t *testing.T) {
 					return shardsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
+						return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', multi[0].Cmd.Commands()[1]), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', multi[0].Cmd.Commands()[1]), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -6509,9 +6509,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -6531,9 +6531,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "ERR some other error"), nil)
+				return NewResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -6550,9 +6550,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -6571,9 +6571,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6588,9 +6588,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6612,9 +6612,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -6635,9 +6635,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -6687,9 +6687,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6713,18 +6713,18 @@ func TestClusterClientMovedRetry(t *testing.T) {
 			for i, cmd := range multi {
 				cmdName := cmd.Commands()[0]
 				if cmdName == "MULTI" {
-					results[i] = newResult(strmsg('+', "OK"), nil)
+					results[i] = NewResult(strmsg('+', "OK"), nil)
 				} else if cmdName == "EXEC" {
 					if attempts == 1 {
 						// return MOVED error only for EXEC on first attempt
 						// making sure we do not panic on wslots connection reassignment because EXEC's "slot" is 16384 (InitSlot)
-						results[i] = newResult(strmsg('-', "MOVED 1 127.0.0.1"), nil)
+						results[i] = NewResult(strmsg('-', "MOVED 1 127.0.0.1"), nil)
 					} else {
 						// return a successful transaction result for the retry
-						results[i] = newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "some_value")}), nil)
+						results[i] = NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "some_value")}), nil)
 					}
 				} else {
-					results[i] = newResult(strmsg('+', "QUEUED"), nil)
+					results[i] = NewResult(strmsg('+', "QUEUED"), nil)
 				}
 			}
 			return &valkeyresults{s: results}
@@ -6757,9 +6757,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 127.0.0.1"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 127.0.0.1"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6783,7 +6783,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Always return MOVED to simulate infinite redirect loop
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6819,7 +6819,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				// Always return MOVED to simulate infinite redirect loop
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6855,7 +6855,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Always return MOVED to simulate infinite redirect loop
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
 			},
 		}
 		client, err := newClusterClient(
@@ -6894,7 +6894,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 				// Always return MOVED to simulate infinite redirect loop
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)}}
 			},
 		}
 		client, err := newClusterClient(
@@ -6933,9 +6933,9 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				attempts++
 				// Return MOVED twice, then success
 				if attempts <= 2 {
-					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -6972,9 +6972,9 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				attempts++
 				// Return MOVED 10 times, then success
 				if attempts <= 10 {
-					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -7015,7 +7015,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				movedCount++
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7062,7 +7062,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Always return MOVED
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7109,14 +7109,14 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				if loopCount == 1 {
 					results := make([]ValkeyResult, len(multi))
 					for i := range results {
-						results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+						results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 					}
 					return &valkeyresults{s: results}
 				}
 				// Second loop: return success
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('+', "OK"), nil)
+					results[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7161,7 +7161,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Always return MOVED
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7203,7 +7203,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Always return MOVED
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -7236,13 +7236,13 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					return slotsMultiResp
 				}
 				// Return ASK error
-				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Return OK for ASKING, and ASK error for the command to simulate infinite loop
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil),
 				}}
 			},
 		}
@@ -7279,7 +7279,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				// Return ASK error
-				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// DoCache with ASK uses askingMultiCache which uses DoMulti
@@ -7293,7 +7293,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 
 				return &valkeyresults{s: []ValkeyResult{
 					{}, {}, {}, {}, {}, // First 5 results (ignored/checked for errors)
-					newResult(slicemsg('*', execResp), nil), // EXEC result
+					NewResult(slicemsg('*', execResp), nil), // EXEC result
 				}}
 			},
 		}
@@ -7343,8 +7343,8 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 					// We need to return [OK, ASK] for each command pair (ASKING, CMD)
 					results := make([]ValkeyResult, len(multi))
 					for i := 0; i < len(multi); i += 2 {
-						results[i] = newResult(strmsg('+', "OK"), nil)                     // ASKING
-						results[i+1] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil) // CMD
+						results[i] = NewResult(strmsg('+', "OK"), nil)                     // ASKING
+						results[i+1] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil) // CMD
 					}
 					return &valkeyresults{s: results}
 				}
@@ -7352,7 +7352,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Initial call (no ASKING)
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7395,7 +7395,7 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// Return ASK error
 				results := make([]ValkeyResult, len(multi))
 				for i := range results {
-					results[i] = newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+					results[i] = NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7404,18 +7404,18 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				results := make([]ValkeyResult, len(multi))
 				for i := 0; i < len(multi); i += 6 {
 					// Fill dummies for first 5
-					results[i] = newResult(strmsg('+', "OK"), nil)
-					results[i+1] = newResult(strmsg('+', "OK"), nil)
-					results[i+2] = newResult(strmsg('+', "OK"), nil)
-					results[i+3] = newResult(strmsg('+', "OK"), nil)
-					results[i+4] = newResult(strmsg('+', "OK"), nil)
+					results[i] = NewResult(strmsg('+', "OK"), nil)
+					results[i+1] = NewResult(strmsg('+', "OK"), nil)
+					results[i+2] = NewResult(strmsg('+', "OK"), nil)
+					results[i+3] = NewResult(strmsg('+', "OK"), nil)
+					results[i+4] = NewResult(strmsg('+', "OK"), nil)
 
 					// EXEC result at index 5
 					execResp := []ValkeyMessage{
 						strmsg('+', "OK"),                   // PTTL result
 						strmsg('-', "ASK 0 127.0.0.1:7001"), // CMD result (ASK)
 					}
-					results[i+5] = newResult(slicemsg('*', execResp), nil)
+					results[i+5] = NewResult(slicemsg('*', execResp), nil)
 				}
 				return &valkeyresults{s: results}
 			},
@@ -7459,16 +7459,16 @@ func TestClusterClientMaxMovedRedirections(t *testing.T) {
 				// 3. (DoMulti handles this step, returning MOVED)
 				// 4. ASK (Limit reached)
 				if attempts == 1 {
-					return newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
+					return NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil)
 				}
-				return newResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
+				return NewResult(strmsg('-', "ASK 0 127.0.0.1:7001"), nil)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				// Used when ASK is handled
 				// Return OK for ASKING, and MOVED for the command
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('-', "MOVED 0 127.0.0.1:7001"), nil),
 				}}
 			},
 		}
@@ -7523,14 +7523,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		attempts := 0
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(ValkeyMessage{typ: '_'}, nil)}}
+				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :0"), nil), NewResult(ValkeyMessage{typ: '_'}, nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7546,14 +7546,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 
 		attempts := 0
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :0"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(ValkeyMessage{typ: '_'}, nil)}}
+				return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, NewResult(strmsg('-', "ASK 0 :0"), nil), NewResult(ValkeyMessage{typ: '_'}, nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -7568,7 +7568,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		askDone := false
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
@@ -7579,7 +7579,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 				t.Errorf("expected 3 cmds on ASK wire under .ToStaticTTL(), got %d", len(multi))
 			}
 			// Reply at offset 2 is the cmd reply directly (no EXEC unwrap).
-			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7594,14 +7594,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		askDone := false
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "ASK 0 :0"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
 			if len(multi) != 3 {
 				t.Errorf("expected 3 cmds on ASK wire under .ToStaticTTL() (1 key × stride 3), got %d", len(multi))
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -7617,7 +7617,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		askDone := false
 		errInjected := false
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			askDone = true
@@ -7635,7 +7635,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 			// the cluster client loops back through pick → DoCache → ASK →
 			// askingMultiCache. On the second pass, succeed so the test
 			// terminates instead of retrying forever.
-			return &valkeyresults{s: []ValkeyResult{{}, {}, newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7653,13 +7653,13 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "MOVED 0 127.0.0.1:0"), nil)
+				return NewResult(strmsg('-', "MOVED 0 127.0.0.1:0"), nil)
 			}
 			// Second call runs on the new owner (ncc.DoCache); cluster
 			// passes the original Cacheable, so the static-TTL tag must
 			// still be set on the retry.
 			taggedOnRetry = cmds.IsStaticTTL(Completed(cmd))
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache().ToStaticTTL(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -7688,7 +7688,7 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 			// Force ASK on both keys so askingMultiCache runs with the mixed batch.
 			rs := make([]ValkeyResult, len(multi))
 			for i := range multi {
-				rs[i] = newResult(strmsg('-', "ASK 0 :0"), nil)
+				rs[i] = NewResult(strmsg('-', "ASK 0 :0"), nil)
 			}
 			return &valkeyresults{s: rs}
 		}
@@ -7705,12 +7705,12 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 			for i := range multi {
 				switch (i + 1) % 6 {
 				case 0: // EXEC reply
-					rs[i] = newResult(slicemsg('*', []ValkeyMessage{
+					rs[i] = NewResult(slicemsg('*', []ValkeyMessage{
 						{typ: ':', intlen: 10000},
 						strmsg('$', "v"),
 					}), nil)
 				default:
-					rs[i] = newResult(strmsg('+', "OK"), nil)
+					rs[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 			}
 			return &valkeyresults{s: rs}
@@ -7739,32 +7739,32 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET Do V"), nil)
+				return NewResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -7778,20 +7778,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -7803,20 +7803,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -8045,9 +8045,9 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -8107,23 +8107,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8215,23 +8215,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8328,40 +8328,40 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -8546,9 +8546,9 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -8609,23 +8609,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8717,23 +8717,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -8829,7 +8829,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 					return slotsMultiResp
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			},
 		}
 		client, err := newClusterClient(
@@ -8853,7 +8853,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return NewErrorResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8870,11 +8870,11 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			}
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
-				return newResult(strmsg('-', "MOVED 0 :1"), nil)
+				return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
 				return NewErrorResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8889,13 +8889,13 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 				return slotsMultiResp
 			}
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewResult(strmsg('+', "OK"), nil)}}
 		}
 		c := client.B().Get().Key("Do").Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "OK" {
@@ -8914,7 +8914,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return NewErrorResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8931,11 +8931,11 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			}
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
-				return newResult(strmsg('-', "MOVED 0 :1"), nil)
+				return NewResult(strmsg('-', "MOVED 0 :1"), nil)
 			case 2:
 				return NewErrorResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8947,13 +8947,13 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newResult(strmsg('-', "ASK 0 :0"), nil)
+			return NewResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return &valkeyresults{s: []ValkeyResult{{}, NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "OK")}), nil)}}
+			return &valkeyresults{s: []ValkeyResult{{}, {}, {}, {}, {}, NewResult(slicemsg('*', []ValkeyMessage{{}, strmsg('+', "OK")}), nil)}}
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8968,7 +8968,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -8981,10 +8981,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		m.DoFn = func(cmd Completed) ValkeyResult { return slotsMultiResp }
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -9014,7 +9014,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "1"), nil),
+					NewResult(strmsg('+', "1"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
@@ -9022,8 +9022,8 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
@@ -9031,9 +9031,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 5: // errConnExpired at end of processing
@@ -9041,10 +9041,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
@@ -9055,7 +9055,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -9098,15 +9098,15 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1:
 				for i := range ret {
-					ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+					ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 				}
 				return &valkeyresults{s: ret}
 			case 2:
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			}
 			for i := 0; i < len(multi); i += 2 {
-				ret[i] = newResult(strmsg('+', "OK"), nil)
-				ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
+				ret[i] = NewResult(strmsg('+', "OK"), nil)
+				ret[i+1] = NewResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 			}
 			return &valkeyresults{s: ret}
 		}
@@ -9138,10 +9138,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				ret := make([]ValkeyResult, len(multi))
 				for i := range ret {
 					if isMulti(multi[i]) || isExec(multi[i]) {
-						ret[i] = newResult(strmsg('+', "OK"), nil)
+						ret[i] = NewResult(strmsg('+', "OK"), nil)
 						continue
 					}
-					ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+					ret[i] = NewResult(strmsg('-', "ASK 0 :1"), nil)
 				}
 				return &valkeyresults{s: ret}
 			case 2: // errConnExpired at the head of processing
@@ -9152,8 +9152,8 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "1"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "1"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Multi command
@@ -9161,7 +9161,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Asking command before Multi command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "OK"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 5: // errConnExpired in the middle of transaction block
@@ -9169,9 +9169,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 6: // errConnExpired at Exec Command
@@ -9179,9 +9179,9 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 7: // errConnExpired at end of processing
@@ -9189,14 +9189,14 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "OK"), nil),
 					NewErrorResult(errConnExpired),
 				}}
 			case 8:
@@ -9204,7 +9204,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -9246,7 +9246,7 @@ func TestClusterClientConnLifetime(t *testing.T) {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -9258,10 +9258,10 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			// recover the failure of the first call
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {
@@ -9299,14 +9299,14 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -9315,13 +9315,13 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 	}
@@ -9329,31 +9329,31 @@ func TestClusterClient_SendToAlternatePrimaryAndReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -9440,40 +9440,40 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -9658,9 +9658,9 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -9721,23 +9721,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -9829,23 +9829,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenPrimaryNodeSele
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -9941,40 +9941,40 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -10159,9 +10159,9 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -10222,23 +10222,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10330,23 +10330,23 @@ func TestClusterClient_ReadNodeSelector_SendToOnlyPrimaryNodeWhenIndexIsOutOfRan
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10442,32 +10442,32 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET Do V"), nil)
+				return NewResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
+				return NewResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(strmsg('+', "MULTI"), nil)
+					resps[i] = NewResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(strmsg('+', "EXEC"), nil)
+					resps[i] = NewResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -10481,20 +10481,20 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -10506,20 +10506,20 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{a}"), nil)
+				return NewResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -10748,9 +10748,9 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -10810,23 +10810,23 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -10918,23 +10918,23 @@ func TestClusterClient_ReadNodeSelector_SendReadOperationToReplicaNodeWriteOpera
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
 				if len(cmd) == 4 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(strmsg('+', "OK"), nil),
-						newResult(slicemsg('*', []ValkeyMessage{
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(strmsg('+', "OK"), nil),
+						NewResult(slicemsg('*', []ValkeyMessage{
 							strmsg('+', "Delegate0"),
 							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "Delegate0"), nil),
-					newResult(strmsg('+', "Delegate1"), nil),
+					NewResult(strmsg('+', "Delegate0"), nil),
+					NewResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -11028,14 +11028,14 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -11044,13 +11044,13 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "INFO"), nil)
+				return NewResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 	}
@@ -11058,31 +11058,31 @@ func TestClusterClient_ReadNodeSelector_SendToAlternatePrimaryAndReplicaNodes(t 
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET Do": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET Do"), nil)
+				return NewResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{a}"), nil)
+				return NewResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{b}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K2{b}"), nil)
+				return NewResult(strmsg('+', "GET K2{b}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) ValkeyResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-				return newResult(strmsg('+', "GET DoCache"), nil)
+				return NewResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -11168,7 +11168,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_Do(t *testing.T) {
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11177,7 +11177,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_Do(t *testing.T) {
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"GET K1{d}": func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "GET K1{d}"), nil)
+				return NewResult(strmsg('+', "GET K1{d}"), nil)
 			},
 		},
 	}
@@ -11219,7 +11219,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMulti(t *testing.T) {
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11229,7 +11229,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMulti(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},
@@ -11274,7 +11274,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 		DoOverride: map[string]func(cmd Completed) ValkeyResult{
 			"CLUSTER SLOTS": func(cmd Completed) ValkeyResult {
 				if atomic.AddInt64(&refresh, 1) == 1 {
-					return newResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
+					return NewResult(slicemsg('*', slotsMultiResp.val.values()[:1]), nil)
 				}
 				return slotsMultiResp
 			},
@@ -11284,7 +11284,7 @@ func TestClusterClient_Refresh_MissingSlotsForReplicas_DoMultiCache(t *testing.T
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 			resps := make([]ValkeyResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = NewResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &valkeyresults{s: resps}
 		},

--- a/helper_test.go
+++ b/helper_test.go
@@ -37,7 +37,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -48,8 +48,8 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -70,7 +70,7 @@ func TestMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := MGetCache(client, ctx, 100, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -117,7 +117,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -128,8 +128,8 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -150,7 +150,7 @@ func TestMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := MGetCache(client, ctx, 100, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -195,7 +195,7 @@ func TestMGetCache(t *testing.T) {
 					for j := 1; j < len(commands); j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = newResult(slicemsg('*', values), nil)
+					result[i] = NewResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -222,7 +222,7 @@ func TestMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', key), nil)
+					result[i] = NewResult(strmsg('+', key), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -247,7 +247,7 @@ func TestMGetCache(t *testing.T) {
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 				result := make([]ValkeyResult, len(multi))
 				for i := range result {
-					result[i] = newErrResult(context.Canceled)
+					result[i] = NewErrResult(context.Canceled)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -277,7 +277,7 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -294,7 +294,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -324,7 +324,7 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -341,7 +341,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -378,7 +378,7 @@ func TestMGet(t *testing.T) {
 					for j := 1; j < len(commands); j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = newResult(slicemsg('*', values), nil)
+					result[i] = NewResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -401,7 +401,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -429,7 +429,7 @@ func TestMDel(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"DEL", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
 			}
 			if v := MDel(client, context.Background(), []string{"1", "2"}); v["1"] != nil || v["2"] != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -444,7 +444,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -474,7 +474,7 @@ func TestMDel(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"DEL", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
 			}
 			if v := MDel(client, context.Background(), []string{"1", "2"}); v["1"] != nil || v["2"] != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -489,7 +489,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -522,7 +522,7 @@ func TestMDel(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(ValkeyMessage{typ: ':', intlen: 1}, nil)
+					result[i] = NewResult(ValkeyMessage{typ: ':', intlen: 1}, nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -542,7 +542,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -570,7 +570,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -585,7 +585,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -616,7 +616,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -631,7 +631,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -669,7 +669,7 @@ func TestMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', "OK"), nil)
+					result[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -693,7 +693,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -721,7 +721,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -736,7 +736,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -767,7 +767,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -782,7 +782,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -820,7 +820,7 @@ func TestMSetNX(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', "OK"), nil)
+					result[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -844,7 +844,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -868,7 +868,7 @@ func TestMSetNXNotSet(t *testing.T) {
 		}
 		t.Run("Delegate Do Not Set", func(t *testing.T) {
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != ErrMSetNXNotSet || err["2"] != ErrMSetNXNotSet {
 				t.Fatalf("unexpected response %v", err)
@@ -895,7 +895,7 @@ func TestMSetNXNotSet(t *testing.T) {
 		}
 		t.Run("Delegate Do Not Set", func(t *testing.T) {
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != ErrMSetNXNotSet || err["2"] != ErrMSetNXNotSet {
 				t.Fatalf("unexpected response %v", err)
@@ -923,8 +923,8 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -945,7 +945,7 @@ func TestJsonMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := JsonMGetCache(client, ctx, 100, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -975,8 +975,8 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -997,7 +997,7 @@ func TestJsonMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := JsonMGetCache(client, ctx, 100, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1030,7 +1030,7 @@ func TestJsonMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', key), nil)
+					result[i] = NewResult(strmsg('+', key), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1055,7 +1055,7 @@ func TestJsonMGetCache(t *testing.T) {
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 				result := make([]ValkeyResult, len(multi))
 				for i := range result {
-					result[i] = newErrResult(context.Canceled)
+					result[i] = NewErrResult(context.Canceled)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1085,7 +1085,7 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1102,7 +1102,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1132,7 +1132,7 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1149,7 +1149,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1190,7 +1190,7 @@ func TestJsonMGet(t *testing.T) {
 					for j := 1; j < len(commands)-1; j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = newResult(slicemsg('*', values), nil)
+					result[i] = NewResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1213,7 +1213,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1241,7 +1241,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -1256,7 +1256,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1287,7 +1287,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -1302,7 +1302,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1340,7 +1340,7 @@ func TestJsonMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', "OK"), nil)
+					result[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -1364,7 +1364,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1691,19 +1691,19 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 	t.Run("standalone client node selectors", func(t *testing.T) {
 		primary := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "primary"), nil)
+				return NewResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string { return primAZ },
 		}
 		replica1 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica1"), nil)
+				return NewResult(strmsg('+', "replica1"), nil)
 			},
 			AZFn: func() string { return rep1AZ },
 		}
 		replica2 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica2"), nil)
+				return NewResult(strmsg('+', "replica2"), nil)
 			},
 			AZFn: func() string { return rep2AZ },
 		}
@@ -1836,20 +1836,20 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 				if strings.Contains(strings.ToUpper(strings.Join(cmd.Commands(), " ")), "CLUSTER SLOTS") {
 					return slotsMultiRespWithMultiReplicas
 				}
-				return newResult(strmsg('+', "primary"), nil)
+				return NewResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string { return primAZ },
 		}
 		rep1 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica1"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica1"), nil) },
 			AZFn: func() string { return rep1AZ },
 		}
 		rep2 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica2"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica2"), nil) },
 			AZFn: func() string { return rep2AZ },
 		}
 		rep3 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica3"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica3"), nil) },
 			AZFn: func() string { return rep3AZ },
 		}
 
@@ -1987,9 +1987,9 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			out := make([]ValkeyResult, len(cmd))
 			for i, c := range cmd {
 				if c.Commands()[1] == "{x}dead" {
-					out[i] = newErrResult(context.DeadlineExceeded)
+					out[i] = NewErrResult(context.DeadlineExceeded)
 				} else {
-					out[i] = newResult(strmsg('+', "OK"), nil)
+					out[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2011,7 +2011,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			out := make([]ValkeyResult, len(cmd))
 			for i := range cmd {
-				out[i] = newResult(strmsg(typeSimpleErr, "ERR oops"), nil)
+				out[i] = NewResult(strmsg(typeSimpleErr, "ERR oops"), nil)
 			}
 			return &valkeyresults{s: out}
 		}
@@ -2054,7 +2054,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			for j := 1; j < len(args); j++ {
 				vals[j-1] = strmsg('+', args[j])
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(slicemsg('*', vals), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(slicemsg('*', vals), nil)}}
 		}
 		v, err := MGet(client, context.Background(), []string{"{s}a", "{s}b"})
 		if err != nil {
@@ -2073,7 +2073,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 				t.Fatalf("want 1 MGET batch, got %d", len(cmd))
 			}
 			// Non-array success: no r.err, so first-loop recycle stays true; ToArray then errors.
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "not-an-array"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "not-an-array"), nil)}}
 		}
 		_, err := MGet(client, context.Background(), []string{"{s}only"})
 		if err == nil {
@@ -2097,9 +2097,9 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					for j := 1; j < len(args); j++ {
 						vals[j-1] = strmsg('+', args[j])
 					}
-					out[i] = newResult(slicemsg('*', vals), nil)
+					out[i] = NewResult(slicemsg('*', vals), nil)
 				} else {
-					out[i] = newErrResult(context.Canceled)
+					out[i] = NewErrResult(context.Canceled)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2117,7 +2117,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			s := make([]ValkeyResult, len(cmd))
 			for i := range s {
-				s[i] = newErrResult(context.Canceled)
+				s[i] = NewErrResult(context.Canceled)
 			}
 			return &valkeyresults{s: s}
 		}
@@ -2157,7 +2157,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			for j := 1; j < len(args)-1; j++ {
 				vals[j-1] = strmsg('+', args[j])
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(slicemsg('*', vals), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(slicemsg('*', vals), nil)}}
 		}
 		v, err := JsonMGet(client, context.Background(), []string{"{s}x", "{s}y"}, "$")
 		if err != nil {
@@ -2175,7 +2175,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			if len(cmd) != 1 {
 				t.Fatalf("want 1 JSON.MGET batch, got %d", len(cmd))
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "not-array"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "not-array"), nil)}}
 		}
 		_, err := JsonMGet(client, context.Background(), []string{"{s}j"}, "$")
 		if err == nil {
@@ -2199,9 +2199,9 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					for j := 1; j < len(args)-1; j++ {
 						vals[j-1] = strmsg('+', args[j])
 					}
-					out[i] = newResult(slicemsg('*', vals), nil)
+					out[i] = NewResult(slicemsg('*', vals), nil)
 				} else {
-					out[i] = newErrResult(context.Canceled)
+					out[i] = NewErrResult(context.Canceled)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2219,7 +2219,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			s := make([]ValkeyResult, len(cmd))
 			for i := range s {
-				s[i] = newErrResult(context.Canceled)
+				s[i] = NewErrResult(context.Canceled)
 			}
 			return &valkeyresults{s: s}
 		}

--- a/helper_test.go
+++ b/helper_test.go
@@ -37,7 +37,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -48,8 +48,8 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -70,7 +70,7 @@ func TestMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := MGetCache(client, ctx, 100, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -117,7 +117,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -128,8 +128,8 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -150,7 +150,7 @@ func TestMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := MGetCache(client, ctx, 100, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -195,7 +195,7 @@ func TestMGetCache(t *testing.T) {
 					for j := 1; j < len(commands); j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = newResult(slicemsg('*', values), nil)
+					result[i] = NewResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -222,7 +222,7 @@ func TestMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', key), nil)
+					result[i] = NewResult(strmsg('+', key), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -277,7 +277,7 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -294,7 +294,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -324,7 +324,7 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -341,7 +341,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -378,7 +378,7 @@ func TestMGet(t *testing.T) {
 					for j := 1; j < len(commands); j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = newResult(slicemsg('*', values), nil)
+					result[i] = NewResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -429,7 +429,7 @@ func TestMDel(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"DEL", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
 			}
 			if v := MDel(client, context.Background(), []string{"1", "2"}); v["1"] != nil || v["2"] != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -444,7 +444,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -474,7 +474,7 @@ func TestMDel(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"DEL", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
 			}
 			if v := MDel(client, context.Background(), []string{"1", "2"}); v["1"] != nil || v["2"] != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -489,7 +489,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -522,7 +522,7 @@ func TestMDel(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(ValkeyMessage{typ: ':', intlen: 1}, nil)
+					result[i] = NewResult(ValkeyMessage{typ: ':', intlen: 1}, nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -570,7 +570,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -585,7 +585,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -616,7 +616,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -631,7 +631,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -669,7 +669,7 @@ func TestMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', "OK"), nil)
+					result[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -721,7 +721,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -736,7 +736,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -767,7 +767,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -782,7 +782,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -820,7 +820,7 @@ func TestMSetNX(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', "OK"), nil)
+					result[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -868,7 +868,7 @@ func TestMSetNXNotSet(t *testing.T) {
 		}
 		t.Run("Delegate Do Not Set", func(t *testing.T) {
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != ErrMSetNXNotSet || err["2"] != ErrMSetNXNotSet {
 				t.Fatalf("unexpected response %v", err)
@@ -895,7 +895,7 @@ func TestMSetNXNotSet(t *testing.T) {
 		}
 		t.Run("Delegate Do Not Set", func(t *testing.T) {
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
+				return NewResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != ErrMSetNXNotSet || err["2"] != ErrMSetNXNotSet {
 				t.Fatalf("unexpected response %v", err)
@@ -923,8 +923,8 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -945,7 +945,7 @@ func TestJsonMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := JsonMGetCache(client, ctx, 100, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -975,8 +975,8 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						newResult(strmsg('+', "1"), nil),
-						newResult(strmsg('+', "2"), nil),
+						NewResult(strmsg('+', "1"), nil),
+						NewResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -997,7 +997,7 @@ func TestJsonMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := JsonMGetCache(client, ctx, 100, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1030,7 +1030,7 @@ func TestJsonMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', key), nil)
+					result[i] = NewResult(strmsg('+', key), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1085,7 +1085,7 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1102,7 +1102,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1132,7 +1132,7 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1149,7 +1149,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1190,7 +1190,7 @@ func TestJsonMGet(t *testing.T) {
 					for j := 1; j < len(commands)-1; j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = newResult(slicemsg('*', values), nil)
+					result[i] = NewResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1241,7 +1241,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -1256,7 +1256,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1287,7 +1287,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -1302,7 +1302,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return newResult(ValkeyMessage{}, context.Canceled)
+				return NewResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1340,7 +1340,7 @@ func TestJsonMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(strmsg('+', "OK"), nil)
+					result[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -1691,19 +1691,19 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 	t.Run("standalone client node selectors", func(t *testing.T) {
 		primary := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "primary"), nil)
+				return NewResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string { return primAZ },
 		}
 		replica1 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica1"), nil)
+				return NewResult(strmsg('+', "replica1"), nil)
 			},
 			AZFn: func() string { return rep1AZ },
 		}
 		replica2 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica2"), nil)
+				return NewResult(strmsg('+', "replica2"), nil)
 			},
 			AZFn: func() string { return rep2AZ },
 		}
@@ -1836,20 +1836,20 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 				if strings.Contains(strings.ToUpper(strings.Join(cmd.Commands(), " ")), "CLUSTER SLOTS") {
 					return slotsMultiRespWithMultiReplicas
 				}
-				return newResult(strmsg('+', "primary"), nil)
+				return NewResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string { return primAZ },
 		}
 		rep1 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica1"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica1"), nil) },
 			AZFn: func() string { return rep1AZ },
 		}
 		rep2 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica2"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica2"), nil) },
 			AZFn: func() string { return rep2AZ },
 		}
 		rep3 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica3"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica3"), nil) },
 			AZFn: func() string { return rep3AZ },
 		}
 
@@ -1989,7 +1989,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 				if c.Commands()[1] == "{x}dead" {
 					out[i] = NewErrorResult(context.DeadlineExceeded)
 				} else {
-					out[i] = newResult(strmsg('+', "OK"), nil)
+					out[i] = NewResult(strmsg('+', "OK"), nil)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2011,7 +2011,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			out := make([]ValkeyResult, len(cmd))
 			for i := range cmd {
-				out[i] = newResult(strmsg(typeSimpleErr, "ERR oops"), nil)
+				out[i] = NewResult(strmsg(typeSimpleErr, "ERR oops"), nil)
 			}
 			return &valkeyresults{s: out}
 		}
@@ -2054,7 +2054,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			for j := 1; j < len(args); j++ {
 				vals[j-1] = strmsg('+', args[j])
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(slicemsg('*', vals), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(slicemsg('*', vals), nil)}}
 		}
 		v, err := MGet(client, context.Background(), []string{"{s}a", "{s}b"})
 		if err != nil {
@@ -2073,7 +2073,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 				t.Fatalf("want 1 MGET batch, got %d", len(cmd))
 			}
 			// Non-array success: no r.err, so first-loop recycle stays true; ToArray then errors.
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "not-an-array"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "not-an-array"), nil)}}
 		}
 		_, err := MGet(client, context.Background(), []string{"{s}only"})
 		if err == nil {
@@ -2097,7 +2097,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					for j := 1; j < len(args); j++ {
 						vals[j-1] = strmsg('+', args[j])
 					}
-					out[i] = newResult(slicemsg('*', vals), nil)
+					out[i] = NewResult(slicemsg('*', vals), nil)
 				} else {
 					out[i] = NewErrorResult(context.Canceled)
 				}
@@ -2157,7 +2157,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			for j := 1; j < len(args)-1; j++ {
 				vals[j-1] = strmsg('+', args[j])
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(slicemsg('*', vals), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(slicemsg('*', vals), nil)}}
 		}
 		v, err := JsonMGet(client, context.Background(), []string{"{s}x", "{s}y"}, "$")
 		if err != nil {
@@ -2175,7 +2175,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			if len(cmd) != 1 {
 				t.Fatalf("want 1 JSON.MGET batch, got %d", len(cmd))
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "not-array"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "not-array"), nil)}}
 		}
 		_, err := JsonMGet(client, context.Background(), []string{"{s}j"}, "$")
 		if err == nil {
@@ -2199,7 +2199,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					for j := 1; j < len(args)-1; j++ {
 						vals[j-1] = strmsg('+', args[j])
 					}
-					out[i] = newResult(slicemsg('*', vals), nil)
+					out[i] = NewResult(slicemsg('*', vals), nil)
 				} else {
 					out[i] = NewErrorResult(context.Canceled)
 				}

--- a/helper_test.go
+++ b/helper_test.go
@@ -247,7 +247,7 @@ func TestMGetCache(t *testing.T) {
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 				result := make([]ValkeyResult, len(multi))
 				for i := range result {
-					result[i] = newErrResult(context.Canceled)
+					result[i] = NewErrorResult(context.Canceled)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -401,7 +401,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.Canceled), NewErrorResult(context.Canceled)}}
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -542,7 +542,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.Canceled), NewErrorResult(context.Canceled)}}
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -693,7 +693,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.Canceled), NewErrorResult(context.Canceled)}}
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -844,7 +844,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.Canceled), NewErrorResult(context.Canceled)}}
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1055,7 +1055,7 @@ func TestJsonMGetCache(t *testing.T) {
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 				result := make([]ValkeyResult, len(multi))
 				for i := range result {
-					result[i] = newErrResult(context.Canceled)
+					result[i] = NewErrorResult(context.Canceled)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1213,7 +1213,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.Canceled), NewErrorResult(context.Canceled)}}
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1364,7 +1364,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.Canceled), NewErrorResult(context.Canceled)}}
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1987,7 +1987,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			out := make([]ValkeyResult, len(cmd))
 			for i, c := range cmd {
 				if c.Commands()[1] == "{x}dead" {
-					out[i] = newErrResult(context.DeadlineExceeded)
+					out[i] = NewErrorResult(context.DeadlineExceeded)
 				} else {
 					out[i] = newResult(strmsg('+', "OK"), nil)
 				}
@@ -2099,7 +2099,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					}
 					out[i] = newResult(slicemsg('*', vals), nil)
 				} else {
-					out[i] = newErrResult(context.Canceled)
+					out[i] = NewErrorResult(context.Canceled)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2117,7 +2117,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			s := make([]ValkeyResult, len(cmd))
 			for i := range s {
-				s[i] = newErrResult(context.Canceled)
+				s[i] = NewErrorResult(context.Canceled)
 			}
 			return &valkeyresults{s: s}
 		}
@@ -2201,7 +2201,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					}
 					out[i] = newResult(slicemsg('*', vals), nil)
 				} else {
-					out[i] = newErrResult(context.Canceled)
+					out[i] = NewErrorResult(context.Canceled)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2219,7 +2219,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			s := make([]ValkeyResult, len(cmd))
 			for i := range s {
-				s[i] = newErrResult(context.Canceled)
+				s[i] = NewErrorResult(context.Canceled)
 			}
 			return &valkeyresults{s: s}
 		}

--- a/helper_test.go
+++ b/helper_test.go
@@ -37,7 +37,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -48,8 +48,8 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "1"), nil),
-						NewResult(strmsg('+', "2"), nil),
+						newResult(strmsg('+', "1"), nil),
+						newResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -70,7 +70,7 @@ func TestMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := MGetCache(client, ctx, 100, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -117,7 +117,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -128,8 +128,8 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "1"), nil),
-						NewResult(strmsg('+', "2"), nil),
+						newResult(strmsg('+', "1"), nil),
+						newResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -150,7 +150,7 @@ func TestMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := MGetCache(client, ctx, 100, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -195,7 +195,7 @@ func TestMGetCache(t *testing.T) {
 					for j := 1; j < len(commands); j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = NewResult(slicemsg('*', values), nil)
+					result[i] = newResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -222,7 +222,7 @@ func TestMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = NewResult(strmsg('+', key), nil)
+					result[i] = newResult(strmsg('+', key), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -247,7 +247,7 @@ func TestMGetCache(t *testing.T) {
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 				result := make([]ValkeyResult, len(multi))
 				for i := range result {
-					result[i] = NewErrResult(context.Canceled)
+					result[i] = newErrResult(context.Canceled)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -277,7 +277,7 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -294,7 +294,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -324,7 +324,7 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -341,7 +341,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -378,7 +378,7 @@ func TestMGet(t *testing.T) {
 					for j := 1; j < len(commands); j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = NewResult(slicemsg('*', values), nil)
+					result[i] = newResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -401,7 +401,7 @@ func TestMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
 			}
 			if v, err := MGet(client, ctx, []string{"1", "2"}); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -429,7 +429,7 @@ func TestMDel(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"DEL", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
+				return newResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
 			}
 			if v := MDel(client, context.Background(), []string{"1", "2"}); v["1"] != nil || v["2"] != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -444,7 +444,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -474,7 +474,7 @@ func TestMDel(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"DEL", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
+				return newResult(ValkeyMessage{typ: ':', intlen: 2}, nil)
 			}
 			if v := MDel(client, context.Background(), []string{"1", "2"}); v["1"] != nil || v["2"] != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -489,7 +489,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -522,7 +522,7 @@ func TestMDel(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = NewResult(ValkeyMessage{typ: ':', intlen: 1}, nil)
+					result[i] = newResult(ValkeyMessage{typ: ':', intlen: 1}, nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -542,7 +542,7 @@ func TestMDel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
 			}
 			if v := MDel(client, ctx, []string{"1", "2"}); v["1"] != context.Canceled || v["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -570,7 +570,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -585,7 +585,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -616,7 +616,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -631,7 +631,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -669,7 +669,7 @@ func TestMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = NewResult(strmsg('+', "OK"), nil)
+					result[i] = newResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -693,7 +693,7 @@ func TestMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
 			}
 			if err := MSet(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -721,7 +721,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -736,7 +736,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -767,7 +767,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -782,7 +782,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -820,7 +820,7 @@ func TestMSetNX(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = NewResult(strmsg('+', "OK"), nil)
+					result[i] = newResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -844,7 +844,7 @@ func TestMSetNX(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
 			}
 			if err := MSetNX(client, ctx, map[string]string{"1": "1", "2": "2"}); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -868,7 +868,7 @@ func TestMSetNXNotSet(t *testing.T) {
 		}
 		t.Run("Delegate Do Not Set", func(t *testing.T) {
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
+				return newResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != ErrMSetNXNotSet || err["2"] != ErrMSetNXNotSet {
 				t.Fatalf("unexpected response %v", err)
@@ -895,7 +895,7 @@ func TestMSetNXNotSet(t *testing.T) {
 		}
 		t.Run("Delegate Do Not Set", func(t *testing.T) {
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
+				return newResult(ValkeyMessage{typ: ':', intlen: 0}, nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != ErrMSetNXNotSet || err["2"] != ErrMSetNXNotSet {
 				t.Fatalf("unexpected response %v", err)
@@ -923,8 +923,8 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "1"), nil),
-						NewResult(strmsg('+', "2"), nil),
+						newResult(strmsg('+', "1"), nil),
+						newResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -945,7 +945,7 @@ func TestJsonMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := JsonMGetCache(client, ctx, 100, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -975,8 +975,8 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &valkeyresults{s: []ValkeyResult{
-						NewResult(strmsg('+', "1"), nil),
-						NewResult(strmsg('+', "2"), nil),
+						newResult(strmsg('+', "1"), nil),
+						newResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -997,7 +997,7 @@ func TestJsonMGetCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(ValkeyMessage{}, context.Canceled), NewResult(ValkeyMessage{}, context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(ValkeyMessage{}, context.Canceled), newResult(ValkeyMessage{}, context.Canceled)}}
 			}
 			if v, err := JsonMGetCache(client, ctx, 100, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1030,7 +1030,7 @@ func TestJsonMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = NewResult(strmsg('+', key), nil)
+					result[i] = newResult(strmsg('+', key), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1055,7 +1055,7 @@ func TestJsonMGetCache(t *testing.T) {
 			m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 				result := make([]ValkeyResult, len(multi))
 				for i := range result {
-					result[i] = NewErrResult(context.Canceled)
+					result[i] = newErrResult(context.Canceled)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1085,7 +1085,7 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1102,7 +1102,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1132,7 +1132,7 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
+				return newResult(slicemsg('*', []ValkeyMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1149,7 +1149,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1190,7 +1190,7 @@ func TestJsonMGet(t *testing.T) {
 					for j := 1; j < len(commands)-1; j++ {
 						values[j-1] = strmsg('+', commands[j])
 					}
-					result[i] = NewResult(slicemsg('*', values), nil)
+					result[i] = newResult(slicemsg('*', values), nil)
 				}
 				return &valkeyresults{s: result}
 			}
@@ -1213,7 +1213,7 @@ func TestJsonMGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
 			}
 			if v, err := JsonMGet(client, ctx, []string{"1", "2"}, "$"); err != context.Canceled {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -1241,7 +1241,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -1256,7 +1256,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1287,7 +1287,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -1302,7 +1302,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoFn = func(cmd Completed) ValkeyResult {
-				return NewResult(ValkeyMessage{}, context.Canceled)
+				return newResult(ValkeyMessage{}, context.Canceled)
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1340,7 +1340,7 @@ func TestJsonMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = NewResult(strmsg('+', "OK"), nil)
+					result[i] = newResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -1364,7 +1364,7 @@ func TestJsonMSet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(context.Canceled), NewErrResult(context.Canceled)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(context.Canceled), newErrResult(context.Canceled)}}
 			}
 			if err := JsonMSet(client, ctx, map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != context.Canceled || err["2"] != context.Canceled {
 				t.Fatalf("unexpected response %v", err)
@@ -1691,19 +1691,19 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 	t.Run("standalone client node selectors", func(t *testing.T) {
 		primary := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "primary"), nil)
+				return newResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string { return primAZ },
 		}
 		replica1 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "replica1"), nil)
+				return newResult(strmsg('+', "replica1"), nil)
 			},
 			AZFn: func() string { return rep1AZ },
 		}
 		replica2 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "replica2"), nil)
+				return newResult(strmsg('+', "replica2"), nil)
 			},
 			AZFn: func() string { return rep2AZ },
 		}
@@ -1836,20 +1836,20 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 				if strings.Contains(strings.ToUpper(strings.Join(cmd.Commands(), " ")), "CLUSTER SLOTS") {
 					return slotsMultiRespWithMultiReplicas
 				}
-				return NewResult(strmsg('+', "primary"), nil)
+				return newResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string { return primAZ },
 		}
 		rep1 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica1"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica1"), nil) },
 			AZFn: func() string { return rep1AZ },
 		}
 		rep2 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica2"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica2"), nil) },
 			AZFn: func() string { return rep2AZ },
 		}
 		rep3 := &mockConn{
-			DoFn: func(cmd Completed) ValkeyResult { return NewResult(strmsg('+', "replica3"), nil) },
+			DoFn: func(cmd Completed) ValkeyResult { return newResult(strmsg('+', "replica3"), nil) },
 			AZFn: func() string { return rep3AZ },
 		}
 
@@ -1987,9 +1987,9 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			out := make([]ValkeyResult, len(cmd))
 			for i, c := range cmd {
 				if c.Commands()[1] == "{x}dead" {
-					out[i] = NewErrResult(context.DeadlineExceeded)
+					out[i] = newErrResult(context.DeadlineExceeded)
 				} else {
-					out[i] = NewResult(strmsg('+', "OK"), nil)
+					out[i] = newResult(strmsg('+', "OK"), nil)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2011,7 +2011,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			out := make([]ValkeyResult, len(cmd))
 			for i := range cmd {
-				out[i] = NewResult(strmsg(typeSimpleErr, "ERR oops"), nil)
+				out[i] = newResult(strmsg(typeSimpleErr, "ERR oops"), nil)
 			}
 			return &valkeyresults{s: out}
 		}
@@ -2054,7 +2054,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			for j := 1; j < len(args); j++ {
 				vals[j-1] = strmsg('+', args[j])
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(slicemsg('*', vals), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(slicemsg('*', vals), nil)}}
 		}
 		v, err := MGet(client, context.Background(), []string{"{s}a", "{s}b"})
 		if err != nil {
@@ -2073,7 +2073,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 				t.Fatalf("want 1 MGET batch, got %d", len(cmd))
 			}
 			// Non-array success: no r.err, so first-loop recycle stays true; ToArray then errors.
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "not-an-array"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "not-an-array"), nil)}}
 		}
 		_, err := MGet(client, context.Background(), []string{"{s}only"})
 		if err == nil {
@@ -2097,9 +2097,9 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					for j := 1; j < len(args); j++ {
 						vals[j-1] = strmsg('+', args[j])
 					}
-					out[i] = NewResult(slicemsg('*', vals), nil)
+					out[i] = newResult(slicemsg('*', vals), nil)
 				} else {
-					out[i] = NewErrResult(context.Canceled)
+					out[i] = newErrResult(context.Canceled)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2117,7 +2117,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			s := make([]ValkeyResult, len(cmd))
 			for i := range s {
-				s[i] = NewErrResult(context.Canceled)
+				s[i] = newErrResult(context.Canceled)
 			}
 			return &valkeyresults{s: s}
 		}
@@ -2157,7 +2157,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			for j := 1; j < len(args)-1; j++ {
 				vals[j-1] = strmsg('+', args[j])
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(slicemsg('*', vals), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(slicemsg('*', vals), nil)}}
 		}
 		v, err := JsonMGet(client, context.Background(), []string{"{s}x", "{s}y"}, "$")
 		if err != nil {
@@ -2175,7 +2175,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 			if len(cmd) != 1 {
 				t.Fatalf("want 1 JSON.MGET batch, got %d", len(cmd))
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "not-array"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "not-array"), nil)}}
 		}
 		_, err := JsonMGet(client, context.Background(), []string{"{s}j"}, "$")
 		if err == nil {
@@ -2199,9 +2199,9 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 					for j := 1; j < len(args)-1; j++ {
 						vals[j-1] = strmsg('+', args[j])
 					}
-					out[i] = NewResult(slicemsg('*', vals), nil)
+					out[i] = newResult(slicemsg('*', vals), nil)
 				} else {
-					out[i] = NewErrResult(context.Canceled)
+					out[i] = newErrResult(context.Canceled)
 				}
 			}
 			return &valkeyresults{s: out}
@@ -2219,7 +2219,7 @@ func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
 		m.DoMultiFn = func(cmd ...Completed) *valkeyresults {
 			s := make([]ValkeyResult, len(cmd))
 			for i := range s {
-				s[i] = NewErrResult(context.Canceled)
+				s[i] = newErrResult(context.Canceled)
 			}
 			return &valkeyresults{s: s}
 		}

--- a/lru.go
+++ b/lru.go
@@ -142,7 +142,7 @@ func (c *lru) Flights(now time.Time, multi []CacheableTTL, results []ValkeyResul
 				if v.typ == 0 {
 					entries[i] = e
 				} else if v.relativePTTL(now) > 0 {
-					results[i] = newResult(v, nil)
+					results[i] = NewResult(v, nil)
 				} else {
 					goto miss1
 				}
@@ -196,7 +196,7 @@ func (c *lru) Flights(now time.Time, multi []CacheableTTL, results []ValkeyResul
 			if v.typ == 0 {
 				entries[i] = e
 			} else if v.relativePTTL(now) > 0 {
-				results[i] = newResult(v, nil)
+				results[i] = NewResult(v, nil)
 			} else {
 				c.list.Remove(ele)
 				c.size -= e.size

--- a/lru.go
+++ b/lru.go
@@ -142,7 +142,7 @@ func (c *lru) Flights(now time.Time, multi []CacheableTTL, results []ValkeyResul
 				if v.typ == 0 {
 					entries[i] = e
 				} else if v.relativePTTL(now) > 0 {
-					results[i] = NewResult(v, nil)
+					results[i] = newResult(v, nil)
 				} else {
 					goto miss1
 				}
@@ -196,7 +196,7 @@ func (c *lru) Flights(now time.Time, multi []CacheableTTL, results []ValkeyResul
 			if v.typ == 0 {
 				entries[i] = e
 			} else if v.relativePTTL(now) > 0 {
-				results[i] = NewResult(v, nil)
+				results[i] = newResult(v, nil)
 			} else {
 				c.list.Remove(ele)
 				c.size -= e.size

--- a/lua.go
+++ b/lua.go
@@ -118,7 +118,7 @@ func (s *Lua) Exec(ctx context.Context, c Client, keys, args []string) (resp Val
 					s.sha1 = shaStr
 				} else {
 					s.sha1Mu.Unlock()
-					return newErrResult(result.Error())
+					return NewErrorResult(result.Error())
 				}
 			}
 			scriptSha1 = s.sha1
@@ -180,7 +180,7 @@ func (s *Lua) ExecMulti(ctx context.Context, c Client, multi ...LuaExec) (resp [
 		if err := e.Load(); err != nil {
 			resp = make([]ValkeyResult, len(multi))
 			for i := 0; i < len(resp); i++ {
-				resp[i] = newErrResult(err.(*errs).error)
+				resp[i] = NewErrorResult(err.(*errs).error)
 			}
 			return
 		}

--- a/lua.go
+++ b/lua.go
@@ -118,7 +118,7 @@ func (s *Lua) Exec(ctx context.Context, c Client, keys, args []string) (resp Val
 					s.sha1 = shaStr
 				} else {
 					s.sha1Mu.Unlock()
-					return newErrResult(result.Error())
+					return NewErrResult(result.Error())
 				}
 			}
 			scriptSha1 = s.sha1
@@ -180,7 +180,7 @@ func (s *Lua) ExecMulti(ctx context.Context, c Client, multi ...LuaExec) (resp [
 		if err := e.Load(); err != nil {
 			resp = make([]ValkeyResult, len(multi))
 			for i := 0; i < len(resp); i++ {
-				resp[i] = newErrResult(err.(*errs).error)
+				resp[i] = NewErrResult(err.(*errs).error)
 			}
 			return
 		}

--- a/lua.go
+++ b/lua.go
@@ -118,7 +118,7 @@ func (s *Lua) Exec(ctx context.Context, c Client, keys, args []string) (resp Val
 					s.sha1 = shaStr
 				} else {
 					s.sha1Mu.Unlock()
-					return NewErrResult(result.Error())
+					return newErrResult(result.Error())
 				}
 			}
 			scriptSha1 = s.sha1
@@ -180,7 +180,7 @@ func (s *Lua) ExecMulti(ctx context.Context, c Client, multi ...LuaExec) (resp [
 		if err := e.Load(); err != nil {
 			resp = make([]ValkeyResult, len(multi))
 			for i := 0; i < len(resp); i++ {
-				resp[i] = NewErrResult(err.(*errs).error)
+				resp[i] = newErrResult(err.(*errs).error)
 			}
 			return
 		}

--- a/lua_test.go
+++ b/lua_test.go
@@ -31,9 +31,9 @@ func TestNewLuaScriptOnePass(t *testing.T) {
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -62,12 +62,12 @@ func TestNewLuaScript(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(strmsg('-', "NOSCRIPT"), nil)
+				return NewResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -96,9 +96,9 @@ func TestNewLuaScriptNoSha(t *testing.T) {
 				t.Fatal("EVALSHA must not be called")
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -127,12 +127,12 @@ func TestNewLuaScriptReadOnly(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(strmsg('-', "NOSCRIPT"), nil)
+				return NewResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -161,9 +161,9 @@ func TestNewLuaScriptReadOnlyNoSha(t *testing.T) {
 				t.Fatal("EVALSHA_RO must not be called")
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -193,17 +193,17 @@ func TestNewLuaScriptRetryable(t *testing.T) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(strmsg('-', "NOSCRIPT"), nil)
+				return NewResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -233,11 +233,11 @@ func TestNewLuaScriptNoShaRetryable(t *testing.T) {
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -260,7 +260,7 @@ func TestNewLuaScriptExecMultiError(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('-', "ANY ERR"), nil)
+			return NewResult(strmsg('-', "ANY ERR"), nil)
 		},
 	}
 
@@ -284,12 +284,12 @@ func TestNewLuaScriptExecMulti(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -314,12 +314,12 @@ func TestNewLuaScriptExecMultiNoSha(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -346,12 +346,12 @@ func TestNewLuaScriptExecMultiRo(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -376,12 +376,12 @@ func TestNewLuaScriptExecMultiRoNoSha(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -501,16 +501,16 @@ func TestNewLuaScriptWithLoadSha1(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				evalshaInvoked = true
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL must not be called when load succeeds")
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -544,10 +544,10 @@ func TestNewLuaScriptWithLoadSha1Error(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
-				return newErrResult(expectedErr)
+				return NewErrResult(expectedErr)
 			}
 			t.Fatal("unexpected command")
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -580,21 +580,21 @@ func TestNewLuaScriptRetryableWithLoadSha1(t *testing.T) {
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				evalshaInvoked = true
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL must not be called when load succeeds")
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -632,16 +632,16 @@ func TestNewLuaScriptReadOnlyWithLoadSha1(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				evalshaRoInvoked = true
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL_RO must not be called when load succeeds")
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -678,12 +678,12 @@ func TestNewLuaScriptWithLoadSha1Concurrent(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCount.Add(1)
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -727,14 +727,14 @@ func TestNewLuaScriptWithLoadSha1ExecMulti(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				} else if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 					t.Fatal("EVAL should not be called when load succeeds")
 				}
@@ -776,7 +776,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 	scriptLoad := func(_, _ bool) expect {
 		return expect{
 			commands: []string{"SCRIPT", "LOAD", body},
-			reply:    newResult(strmsg('+', sha), nil),
+			reply:    NewResult(strmsg('+', sha), nil),
 			attr:     cmdAttr{ReadOnly: false, Retryable: true},
 		}
 	}
@@ -787,7 +787,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 		}
 		return expect{
 			commands: []string{cmd, sha, "2", "1", "2", "3", "4"},
-			reply:    newResult(strmsg('+', "OK"), nil),
+			reply:    NewResult(strmsg('+', "OK"), nil),
 			attr:     cmdAttr{ReadOnly: readOnly, Retryable: readOnly || retryable},
 		}
 	}
@@ -798,7 +798,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 		}
 		return expect{
 			commands: []string{cmd, body, "2", "1", "2", "3", "4"},
-			reply:    newResult(strmsg('+', "OK"), nil),
+			reply:    NewResult(strmsg('+', "OK"), nil),
 			attr:     cmdAttr{ReadOnly: readOnly, Retryable: readOnly || retryable},
 		}
 	}
@@ -813,12 +813,12 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 			for _, e := range expects {
 				if reflect.DeepEqual(commands, e.commands) {
 					if cmd.IsReadOnly() != e.attr.ReadOnly || cmd.IsRetryable() != e.attr.Retryable {
-						return newErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable))
+						return NewErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable))
 					}
 					return e.reply
 				}
 			}
-			return newResult(strmsg('-', "not expected"), nil)
+			return NewResult(strmsg('-', "not expected"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
@@ -827,7 +827,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 				for _, e := range expects {
 					if reflect.DeepEqual(commands, e.commands) {
 						if cmd.IsReadOnly() != e.attr.ReadOnly || cmd.IsRetryable() != e.attr.Retryable {
-							resp = append(resp, newErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable)))
+							resp = append(resp, NewErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable)))
 						} else {
 							resp = append(resp, e.reply)
 						}
@@ -836,7 +836,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 					}
 				}
 				if !found {
-					resp = append(resp, newResult(strmsg('-', "not expected"), nil))
+					resp = append(resp, NewResult(strmsg('-', "not expected"), nil))
 				}
 			}
 			return resp

--- a/lua_test.go
+++ b/lua_test.go
@@ -31,9 +31,9 @@ func TestNewLuaScriptOnePass(t *testing.T) {
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -62,12 +62,12 @@ func TestNewLuaScript(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return NewResult(strmsg('-', "NOSCRIPT"), nil)
+				return newResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-				return NewResult(ValkeyMessage{typ: '_'}, nil)
+				return newResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -96,9 +96,9 @@ func TestNewLuaScriptNoSha(t *testing.T) {
 				t.Fatal("EVALSHA must not be called")
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-				return NewResult(ValkeyMessage{typ: '_'}, nil)
+				return newResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -127,12 +127,12 @@ func TestNewLuaScriptReadOnly(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return NewResult(strmsg('-', "NOSCRIPT"), nil)
+				return newResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-				return NewResult(ValkeyMessage{typ: '_'}, nil)
+				return newResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -161,9 +161,9 @@ func TestNewLuaScriptReadOnlyNoSha(t *testing.T) {
 				t.Fatal("EVALSHA_RO must not be called")
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-				return NewResult(ValkeyMessage{typ: '_'}, nil)
+				return newResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -193,17 +193,17 @@ func TestNewLuaScriptRetryable(t *testing.T) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
 				if !cmd.IsRetryable() {
-					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return NewResult(strmsg('-', "NOSCRIPT"), nil)
+				return newResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				if !cmd.IsRetryable() {
-					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return NewResult(ValkeyMessage{typ: '_'}, nil)
+				return newResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -233,11 +233,11 @@ func TestNewLuaScriptNoShaRetryable(t *testing.T) {
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				if !cmd.IsRetryable() {
-					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return NewResult(ValkeyMessage{typ: '_'}, nil)
+				return newResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -260,7 +260,7 @@ func TestNewLuaScriptExecMultiError(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return NewResult(strmsg('-', "ANY ERR"), nil)
+			return newResult(strmsg('-', "ANY ERR"), nil)
 		},
 	}
 
@@ -284,12 +284,12 @@ func TestNewLuaScriptExecMulti(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -314,12 +314,12 @@ func TestNewLuaScriptExecMultiNoSha(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -346,12 +346,12 @@ func TestNewLuaScriptExecMultiRo(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -376,12 +376,12 @@ func TestNewLuaScriptExecMultiRoNoSha(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -501,16 +501,16 @@ func TestNewLuaScriptWithLoadSha1(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return NewResult(strmsg('+', sha), nil)
+				return newResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				evalshaInvoked = true
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL must not be called when load succeeds")
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -544,10 +544,10 @@ func TestNewLuaScriptWithLoadSha1Error(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
-				return NewErrResult(expectedErr)
+				return newErrResult(expectedErr)
 			}
 			t.Fatal("unexpected command")
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -580,21 +580,21 @@ func TestNewLuaScriptRetryableWithLoadSha1(t *testing.T) {
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
 				if !cmd.IsRetryable() {
-					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return NewResult(strmsg('+', sha), nil)
+				return newResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				evalshaInvoked = true
 				if !cmd.IsRetryable() {
-					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL must not be called when load succeeds")
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -632,16 +632,16 @@ func TestNewLuaScriptReadOnlyWithLoadSha1(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return NewResult(strmsg('+', sha), nil)
+				return newResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				evalshaRoInvoked = true
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL_RO must not be called when load succeeds")
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -678,12 +678,12 @@ func TestNewLuaScriptWithLoadSha1Concurrent(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCount.Add(1)
-				return NewResult(strmsg('+', sha), nil)
+				return newResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return NewResult(strmsg('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
-			return NewResult(strmsg('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -727,14 +727,14 @@ func TestNewLuaScriptWithLoadSha1ExecMulti(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return NewResult(strmsg('+', sha), nil)
+				return newResult(strmsg('+', sha), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
 				} else if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 					t.Fatal("EVAL should not be called when load succeeds")
 				}
@@ -776,7 +776,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 	scriptLoad := func(_, _ bool) expect {
 		return expect{
 			commands: []string{"SCRIPT", "LOAD", body},
-			reply:    NewResult(strmsg('+', sha), nil),
+			reply:    newResult(strmsg('+', sha), nil),
 			attr:     cmdAttr{ReadOnly: false, Retryable: true},
 		}
 	}
@@ -787,7 +787,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 		}
 		return expect{
 			commands: []string{cmd, sha, "2", "1", "2", "3", "4"},
-			reply:    NewResult(strmsg('+', "OK"), nil),
+			reply:    newResult(strmsg('+', "OK"), nil),
 			attr:     cmdAttr{ReadOnly: readOnly, Retryable: readOnly || retryable},
 		}
 	}
@@ -798,7 +798,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 		}
 		return expect{
 			commands: []string{cmd, body, "2", "1", "2", "3", "4"},
-			reply:    NewResult(strmsg('+', "OK"), nil),
+			reply:    newResult(strmsg('+', "OK"), nil),
 			attr:     cmdAttr{ReadOnly: readOnly, Retryable: readOnly || retryable},
 		}
 	}
@@ -813,12 +813,12 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 			for _, e := range expects {
 				if reflect.DeepEqual(commands, e.commands) {
 					if cmd.IsReadOnly() != e.attr.ReadOnly || cmd.IsRetryable() != e.attr.Retryable {
-						return NewErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable))
+						return newErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable))
 					}
 					return e.reply
 				}
 			}
-			return NewResult(strmsg('-', "not expected"), nil)
+			return newResult(strmsg('-', "not expected"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
@@ -827,7 +827,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 				for _, e := range expects {
 					if reflect.DeepEqual(commands, e.commands) {
 						if cmd.IsReadOnly() != e.attr.ReadOnly || cmd.IsRetryable() != e.attr.Retryable {
-							resp = append(resp, NewErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable)))
+							resp = append(resp, newErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable)))
 						} else {
 							resp = append(resp, e.reply)
 						}
@@ -836,7 +836,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 					}
 				}
 				if !found {
-					resp = append(resp, NewResult(strmsg('-', "not expected"), nil))
+					resp = append(resp, newResult(strmsg('-', "not expected"), nil))
 				}
 			}
 			return resp

--- a/lua_test.go
+++ b/lua_test.go
@@ -31,9 +31,9 @@ func TestNewLuaScriptOnePass(t *testing.T) {
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -62,12 +62,12 @@ func TestNewLuaScript(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(strmsg('-', "NOSCRIPT"), nil)
+				return NewResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -96,9 +96,9 @@ func TestNewLuaScriptNoSha(t *testing.T) {
 				t.Fatal("EVALSHA must not be called")
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -127,12 +127,12 @@ func TestNewLuaScriptReadOnly(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(strmsg('-', "NOSCRIPT"), nil)
+				return NewResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -161,9 +161,9 @@ func TestNewLuaScriptReadOnlyNoSha(t *testing.T) {
 				t.Fatal("EVALSHA_RO must not be called")
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -193,17 +193,17 @@ func TestNewLuaScriptRetryable(t *testing.T) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(strmsg('-', "NOSCRIPT"), nil)
+				return NewResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -233,11 +233,11 @@ func TestNewLuaScriptNoShaRetryable(t *testing.T) {
 			}
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(ValkeyMessage{typ: '_'}, nil)
+				return NewResult(ValkeyMessage{typ: '_'}, nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -260,7 +260,7 @@ func TestNewLuaScriptExecMultiError(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('-', "ANY ERR"), nil)
+			return NewResult(strmsg('-', "ANY ERR"), nil)
 		},
 	}
 
@@ -284,12 +284,12 @@ func TestNewLuaScriptExecMulti(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -314,12 +314,12 @@ func TestNewLuaScriptExecMultiNoSha(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -346,12 +346,12 @@ func TestNewLuaScriptExecMultiRo(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -376,12 +376,12 @@ func TestNewLuaScriptExecMultiRoNoSha(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -501,16 +501,16 @@ func TestNewLuaScriptWithLoadSha1(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				evalshaInvoked = true
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL must not be called when load succeeds")
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -547,7 +547,7 @@ func TestNewLuaScriptWithLoadSha1Error(t *testing.T) {
 				return NewErrorResult(expectedErr)
 			}
 			t.Fatal("unexpected command")
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -580,21 +580,21 @@ func TestNewLuaScriptRetryableWithLoadSha1(t *testing.T) {
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				evalshaInvoked = true
 				if !cmd.IsRetryable() {
-					return newResult(strmsg('-', "cmd retryable unexpected"), nil)
+					return NewResult(strmsg('-', "cmd retryable unexpected"), nil)
 				}
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL must not be called when load succeeds")
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -632,16 +632,16 @@ func TestNewLuaScriptReadOnlyWithLoadSha1(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				evalshaRoInvoked = true
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
 				t.Fatal("EVAL_RO must not be called when load succeeds")
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -678,12 +678,12 @@ func TestNewLuaScriptWithLoadSha1Concurrent(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCount.Add(1)
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
 			if reflect.DeepEqual(commands, []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return newResult(strmsg('+', "OK"), nil)
+				return NewResult(strmsg('+', "OK"), nil)
 			}
-			return newResult(strmsg('+', "unexpected"), nil)
+			return NewResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -727,14 +727,14 @@ func TestNewLuaScriptWithLoadSha1ExecMulti(t *testing.T) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
 				scriptLoadCalled = true
-				return newResult(strmsg('+', sha), nil)
+				return NewResult(strmsg('+', sha), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+					resp = append(resp, NewResult(strmsg('+', "OK"), nil))
 				} else if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 					t.Fatal("EVAL should not be called when load succeeds")
 				}
@@ -776,7 +776,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 	scriptLoad := func(_, _ bool) expect {
 		return expect{
 			commands: []string{"SCRIPT", "LOAD", body},
-			reply:    newResult(strmsg('+', sha), nil),
+			reply:    NewResult(strmsg('+', sha), nil),
 			attr:     cmdAttr{ReadOnly: false, Retryable: true},
 		}
 	}
@@ -787,7 +787,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 		}
 		return expect{
 			commands: []string{cmd, sha, "2", "1", "2", "3", "4"},
-			reply:    newResult(strmsg('+', "OK"), nil),
+			reply:    NewResult(strmsg('+', "OK"), nil),
 			attr:     cmdAttr{ReadOnly: readOnly, Retryable: readOnly || retryable},
 		}
 	}
@@ -798,7 +798,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 		}
 		return expect{
 			commands: []string{cmd, body, "2", "1", "2", "3", "4"},
-			reply:    newResult(strmsg('+', "OK"), nil),
+			reply:    NewResult(strmsg('+', "OK"), nil),
 			attr:     cmdAttr{ReadOnly: readOnly, Retryable: readOnly || retryable},
 		}
 	}
@@ -818,7 +818,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 					return e.reply
 				}
 			}
-			return newResult(strmsg('-', "not expected"), nil)
+			return NewResult(strmsg('-', "not expected"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []ValkeyResult) {
 			for _, cmd := range multi {
@@ -836,7 +836,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 					}
 				}
 				if !found {
-					resp = append(resp, newResult(strmsg('-', "not expected"), nil))
+					resp = append(resp, NewResult(strmsg('-', "not expected"), nil))
 				}
 			}
 			return resp

--- a/lua_test.go
+++ b/lua_test.go
@@ -544,7 +544,7 @@ func TestNewLuaScriptWithLoadSha1Error(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 			commands := cmd.Commands()
 			if reflect.DeepEqual(commands, []string{"SCRIPT", "LOAD", body}) {
-				return newErrResult(expectedErr)
+				return NewErrorResult(expectedErr)
 			}
 			t.Fatal("unexpected command")
 			return newResult(strmsg('+', "unexpected"), nil)
@@ -813,7 +813,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 			for _, e := range expects {
 				if reflect.DeepEqual(commands, e.commands) {
 					if cmd.IsReadOnly() != e.attr.ReadOnly || cmd.IsRetryable() != e.attr.Retryable {
-						return newErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable))
+						return NewErrorResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable))
 					}
 					return e.reply
 				}
@@ -827,7 +827,7 @@ func TestNewLuaScript_MayRetryable(t *testing.T) {
 				for _, e := range expects {
 					if reflect.DeepEqual(commands, e.commands) {
 						if cmd.IsReadOnly() != e.attr.ReadOnly || cmd.IsRetryable() != e.attr.Retryable {
-							resp = append(resp, newErrResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable)))
+							resp = append(resp, NewErrorResult(fmt.Errorf("cmd attr not match, %v %v %v %v", cmd.IsReadOnly(), e.attr.ReadOnly, cmd.IsRetryable(), e.attr.Retryable)))
 						} else {
 							resp = append(resp, e.reply)
 						}

--- a/message.go
+++ b/message.go
@@ -130,7 +130,9 @@ func (r *ValkeyError) IsBusyGroup() bool {
 	return strings.HasPrefix(r.string(), "BUSYGROUP")
 }
 
-func newResult(val ValkeyMessage, err error) ValkeyResult {
+// NewResult returns a ValkeyResult with the provided ValkeyMessage and error. This is mostly useful for implementing
+// hooks or mocking.
+func NewResult(val ValkeyMessage, err error) ValkeyResult {
 	return ValkeyResult{val: val, err: err}
 }
 

--- a/message.go
+++ b/message.go
@@ -130,13 +130,11 @@ func (r *ValkeyError) IsBusyGroup() bool {
 	return strings.HasPrefix(r.string(), "BUSYGROUP")
 }
 
-// NewResult creates a new ValkeyResult with the provided ValkeyMessage and error.
-func NewResult(val ValkeyMessage, err error) ValkeyResult {
+func newResult(val ValkeyMessage, err error) ValkeyResult {
 	return ValkeyResult{val: val, err: err}
 }
 
-// NewErrResult creates a new ValkeyResult with the provided error.
-func NewErrResult(err error) ValkeyResult {
+func newErrResult(err error) ValkeyResult {
 	return ValkeyResult{err: err}
 }
 

--- a/message.go
+++ b/message.go
@@ -134,7 +134,9 @@ func newResult(val ValkeyMessage, err error) ValkeyResult {
 	return ValkeyResult{val: val, err: err}
 }
 
-func newErrResult(err error) ValkeyResult {
+// NewErrorResult returns a ValkeyResult with the provided error. This is useful for implementing
+// hooks or mocking.
+func NewErrorResult(err error) ValkeyResult {
 	return ValkeyResult{err: err}
 }
 

--- a/message.go
+++ b/message.go
@@ -130,11 +130,13 @@ func (r *ValkeyError) IsBusyGroup() bool {
 	return strings.HasPrefix(r.string(), "BUSYGROUP")
 }
 
-func newResult(val ValkeyMessage, err error) ValkeyResult {
+// NewResult creates a new ValkeyResult with the provided ValkeyMessage and error.
+func NewResult(val ValkeyMessage, err error) ValkeyResult {
 	return ValkeyResult{val: val, err: err}
 }
 
-func newErrResult(err error) ValkeyResult {
+// NewErrResult creates a new ValkeyResult with the provided error.
+func NewErrResult(err error) ValkeyResult {
 	return ValkeyResult{err: err}
 }
 

--- a/mock/result.go
+++ b/mock/result.go
@@ -15,13 +15,11 @@ import (
 )
 
 func Result(val valkey.ValkeyMessage) valkey.ValkeyResult {
-	r := result{val: val}
-	return *(*valkey.ValkeyResult)(unsafe.Pointer(&r))
+	return valkey.NewResult(val, nil)
 }
 
 func ErrorResult(err error) valkey.ValkeyResult {
-	r := result{err: err}
-	return *(*valkey.ValkeyResult)(unsafe.Pointer(&r))
+	return valkey.NewErrorResult(err)
 }
 
 func ValkeyString(v string) valkey.ValkeyMessage {
@@ -162,11 +160,6 @@ func strmsg(typ byte, value string) message {
 		bytes:   unsafe.StringData(value),
 		integer: int64(len(value)),
 	}
-}
-
-type result struct {
-	err error
-	val valkey.ValkeyMessage
 }
 
 type pool struct {

--- a/mux_test.go
+++ b/mux_test.go
@@ -659,7 +659,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoStreamFn: func(pool *pool, cmd Completed) ValkeyResultStream {
-					return ValkeyResultStream{e: errors.New(cmd.Commands()[0])}
+					return NewErrorResultStream(errors.New(cmd.Commands()[0]))
 				},
 			},
 		})

--- a/mux_test.go
+++ b/mux_test.go
@@ -211,7 +211,7 @@ func TestMuxReuseWire(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "PONG"), nil)
+					return newResult(strmsg('+', "PONG"), nil)
 				},
 			},
 		})
@@ -234,7 +234,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "ACQUIRED"), nil)
+					return newResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -271,7 +271,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -282,12 +282,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "PIPELINED"), nil)
+					return newResult(strmsg('+', "PIPELINED"), nil)
 				},
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "ACQUIRED"), nil)
+					return newResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -332,7 +332,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -343,12 +343,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "PIPELINED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "PIPELINED"), nil)}}
 				},
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "ACQUIRED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -393,7 +393,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -406,7 +406,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "ACQUIRED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -443,7 +443,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -493,7 +493,7 @@ func TestMuxReuseWire(t *testing.T) {
 					got := cmd.Commands()
 					if len(got) == 3 && got[0] == "CLIENT" && got[1] == "TRACKING" && got[2] == "OFF" {
 						trackingOffCalls++
-						return NewResult(strmsg('+', "OK"), nil)
+						return newResult(strmsg('+', "OK"), nil)
 					}
 					t.Fatalf("unexpected command: %v", got)
 					return ValkeyResult{}
@@ -535,7 +535,7 @@ func TestMuxReuseWire(t *testing.T) {
 				},
 				DoFn: func(cmd Completed) ValkeyResult {
 					doCalled = true
-					return NewResult(strmsg('+', "OK"), nil)
+					return newResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -628,7 +628,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewErrResult(context.DeadlineExceeded)
+					return newErrResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -639,7 +639,7 @@ func TestMuxDelegation(t *testing.T) {
 					if cmd.Commands()[0] != "READONLY_COMMAND" {
 						t.Fatalf("command should be READONLY_COMMAND")
 					}
-					return NewResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -674,7 +674,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -682,7 +682,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -717,7 +717,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-					return NewErrResult(context.DeadlineExceeded)
+					return newErrResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -725,7 +725,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-					return NewResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -745,7 +745,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -753,7 +753,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -779,9 +779,9 @@ func TestMuxDelegation(t *testing.T) {
 					result := make([]ValkeyResult, len(multi))
 					for j, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
-							result[j] = NewErrResult(fmt.Errorf("wrong slot %v %v", s, idx))
+							result[j] = newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))
 						} else {
-							result[j] = NewResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
+							result[j] = newResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
 						}
 					}
 					return &valkeyresults{s: result}
@@ -820,10 +820,10 @@ func TestMuxDelegation(t *testing.T) {
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					for _, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
-							return &valkeyresults{s: []ValkeyResult{NewErrResult(fmt.Errorf("wrong slot %v %v", s, idx))}}
+							return &valkeyresults{s: []ValkeyResult{newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))}}
 						}
 					}
-					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -921,7 +921,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -934,7 +934,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewErrResult(context.DeadlineExceeded)
+					return newErrResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -945,7 +945,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "OK"), nil)
+					return newResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -1013,7 +1013,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1066,7 +1066,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1079,7 +1079,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -1090,7 +1090,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "OK"), nil)
+					return newResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -1123,7 +1123,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "PONG1"), nil)
+					return newResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)
@@ -1131,7 +1131,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "PONG2"), nil)
+					return newResult(strmsg('+', "PONG2"), nil)
 				},
 			},
 		})
@@ -1150,7 +1150,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return NewResult(strmsg('+', "PONG1"), nil)
+					return newResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)

--- a/mux_test.go
+++ b/mux_test.go
@@ -211,7 +211,7 @@ func TestMuxReuseWire(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG"), nil)
+					return NewResult(strmsg('+', "PONG"), nil)
 				},
 			},
 		})
@@ -234,7 +234,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "ACQUIRED"), nil)
+					return NewResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -271,7 +271,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -282,12 +282,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PIPELINED"), nil)
+					return NewResult(strmsg('+', "PIPELINED"), nil)
 				},
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "ACQUIRED"), nil)
+					return NewResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -332,7 +332,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -343,12 +343,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "PIPELINED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "PIPELINED"), nil)}}
 				},
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -393,7 +393,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -406,7 +406,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -443,7 +443,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -493,7 +493,7 @@ func TestMuxReuseWire(t *testing.T) {
 					got := cmd.Commands()
 					if len(got) == 3 && got[0] == "CLIENT" && got[1] == "TRACKING" && got[2] == "OFF" {
 						trackingOffCalls++
-						return newResult(strmsg('+', "OK"), nil)
+						return NewResult(strmsg('+', "OK"), nil)
 					}
 					t.Fatalf("unexpected command: %v", got)
 					return ValkeyResult{}
@@ -535,7 +535,7 @@ func TestMuxReuseWire(t *testing.T) {
 				},
 				DoFn: func(cmd Completed) ValkeyResult {
 					doCalled = true
-					return newResult(strmsg('+', "OK"), nil)
+					return NewResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -628,7 +628,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newErrResult(context.DeadlineExceeded)
+					return NewErrResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -639,7 +639,7 @@ func TestMuxDelegation(t *testing.T) {
 					if cmd.Commands()[0] != "READONLY_COMMAND" {
 						t.Fatalf("command should be READONLY_COMMAND")
 					}
-					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return NewResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -674,7 +674,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -682,7 +682,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -717,7 +717,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-					return newErrResult(context.DeadlineExceeded)
+					return NewErrResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -725,7 +725,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return NewResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -745,7 +745,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -753,7 +753,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -779,9 +779,9 @@ func TestMuxDelegation(t *testing.T) {
 					result := make([]ValkeyResult, len(multi))
 					for j, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
-							result[j] = newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))
+							result[j] = NewErrResult(fmt.Errorf("wrong slot %v %v", s, idx))
 						} else {
-							result[j] = newResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
+							result[j] = NewResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
 						}
 					}
 					return &valkeyresults{s: result}
@@ -820,10 +820,10 @@ func TestMuxDelegation(t *testing.T) {
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					for _, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
-							return &valkeyresults{s: []ValkeyResult{newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))}}
+							return &valkeyresults{s: []ValkeyResult{NewErrResult(fmt.Errorf("wrong slot %v %v", s, idx))}}
 						}
 					}
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -921,7 +921,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -934,7 +934,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newErrResult(context.DeadlineExceeded)
+					return NewErrResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -945,7 +945,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "OK"), nil)
+					return NewResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -1013,7 +1013,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1066,7 +1066,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1079,7 +1079,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -1090,7 +1090,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "OK"), nil)
+					return NewResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -1123,7 +1123,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG1"), nil)
+					return NewResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)
@@ -1131,7 +1131,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG2"), nil)
+					return NewResult(strmsg('+', "PONG2"), nil)
 				},
 			},
 		})
@@ -1150,7 +1150,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG1"), nil)
+					return NewResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)

--- a/mux_test.go
+++ b/mux_test.go
@@ -628,7 +628,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newErrResult(context.DeadlineExceeded)
+					return NewErrorResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -674,7 +674,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -717,7 +717,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-					return newErrResult(context.DeadlineExceeded)
+					return NewErrorResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -745,7 +745,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -779,7 +779,7 @@ func TestMuxDelegation(t *testing.T) {
 					result := make([]ValkeyResult, len(multi))
 					for j, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
-							result[j] = newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))
+							result[j] = NewErrorResult(fmt.Errorf("wrong slot %v %v", s, idx))
 						} else {
 							result[j] = newResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
 						}
@@ -820,10 +820,10 @@ func TestMuxDelegation(t *testing.T) {
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
 					for _, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
-							return &valkeyresults{s: []ValkeyResult{newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))}}
+							return &valkeyresults{s: []ValkeyResult{NewErrorResult(fmt.Errorf("wrong slot %v %v", s, idx))}}
 						}
 					}
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -934,7 +934,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newErrResult(context.DeadlineExceeded)
+					return NewErrorResult(context.DeadlineExceeded)
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -1079,7 +1079,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newErrResult(context.DeadlineExceeded)}}
+					return &valkeyresults{s: []ValkeyResult{NewErrorResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded

--- a/mux_test.go
+++ b/mux_test.go
@@ -211,7 +211,7 @@ func TestMuxReuseWire(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG"), nil)
+					return NewResult(strmsg('+', "PONG"), nil)
 				},
 			},
 		})
@@ -234,7 +234,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "ACQUIRED"), nil)
+					return NewResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -271,7 +271,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -282,12 +282,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PIPELINED"), nil)
+					return NewResult(strmsg('+', "PIPELINED"), nil)
 				},
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "ACQUIRED"), nil)
+					return NewResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -332,7 +332,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -343,12 +343,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "PIPELINED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "PIPELINED"), nil)}}
 				},
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -393,7 +393,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -406,7 +406,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -443,7 +443,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
+		response <- NewResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -493,7 +493,7 @@ func TestMuxReuseWire(t *testing.T) {
 					got := cmd.Commands()
 					if len(got) == 3 && got[0] == "CLIENT" && got[1] == "TRACKING" && got[2] == "OFF" {
 						trackingOffCalls++
-						return newResult(strmsg('+', "OK"), nil)
+						return NewResult(strmsg('+', "OK"), nil)
 					}
 					t.Fatalf("unexpected command: %v", got)
 					return ValkeyResult{}
@@ -535,7 +535,7 @@ func TestMuxReuseWire(t *testing.T) {
 				},
 				DoFn: func(cmd Completed) ValkeyResult {
 					doCalled = true
-					return newResult(strmsg('+', "OK"), nil)
+					return NewResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -639,7 +639,7 @@ func TestMuxDelegation(t *testing.T) {
 					if cmd.Commands()[0] != "READONLY_COMMAND" {
 						t.Fatalf("command should be READONLY_COMMAND")
 					}
-					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return NewResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -682,7 +682,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(multi ...Completed) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -725,7 +725,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return NewResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -753,7 +753,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-					return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -781,7 +781,7 @@ func TestMuxDelegation(t *testing.T) {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
 							result[j] = NewErrorResult(fmt.Errorf("wrong slot %v %v", s, idx))
 						} else {
-							result[j] = newResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
+							result[j] = NewResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
 						}
 					}
 					return &valkeyresults{s: result}
@@ -921,7 +921,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -945,7 +945,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "OK"), nil)
+					return NewResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -1013,7 +1013,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1066,7 +1066,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for range 2 {
-			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- NewResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1090,7 +1090,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "OK"), nil)
+					return NewResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -1123,7 +1123,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG1"), nil)
+					return NewResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)
@@ -1131,7 +1131,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG2"), nil)
+					return NewResult(strmsg('+', "PONG2"), nil)
 				},
 			},
 		})
@@ -1150,7 +1150,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) ValkeyResult {
-					return newResult(strmsg('+', "PONG1"), nil)
+					return NewResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)

--- a/pipe.go
+++ b/pipe.go
@@ -460,7 +460,7 @@ func (p *pipe) _background() {
 		old.hooks.onInvalidations(nil)
 	}
 
-	resp := NewErrResult(err)
+	resp := newErrResult(err)
 	for p.loadWaits() != 0 {
 		select {
 		case <-p.close: // p.queue.NextWriteCmd() can only be called after _backgroundWrite
@@ -548,9 +548,9 @@ func (p *pipe) _backgroundRead() (err error) {
 	)
 
 	defer func() {
-		resp := NewErrResult(err)
+		resp := newErrResult(err)
 		if e := p.Error(); e == errConnExpired {
-			resp = NewErrResult(e)
+			resp = newErrResult(e)
 		}
 		if err != nil && ff < len(multi) {
 			for ; ff < len(resps); ff++ {
@@ -693,7 +693,7 @@ func (p *pipe) _backgroundRead() (err error) {
 			skipUnsubReply = false
 			continue
 		}
-		resp := NewResult(msg, err)
+		resp := newResult(msg, err)
 		if resps != nil {
 			resps[ff] = resp
 		}
@@ -1020,7 +1020,7 @@ func (p *pipe) AZ() string {
 
 func (p *pipe) Do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 	if err := ctx.Err(); err != nil {
-		return NewErrResult(err)
+		return newErrResult(err)
 	}
 
 	cmds.CompletedCS(cmd).Verify()
@@ -1060,7 +1060,7 @@ func (p *pipe) Do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 		}
 		resp = p.syncDo(dl, ok, cmd)
 	} else {
-		resp = NewErrResult(p.Error())
+		resp = newErrResult(p.Error())
 	}
 
 	if left := p.decrWaitsAndIncrRecvs(); state == 0 && left != 0 {
@@ -1072,7 +1072,7 @@ queue:
 	ch, err := p.queue.PutOne(ctx, cmd)
 	if err != nil {
 		p.decrWaits()
-		return NewErrResult(err)
+		return newErrResult(err)
 	}
 
 	if ctxCh := ctx.Done(); ctxCh == nil {
@@ -1091,14 +1091,14 @@ abort:
 		<-ch
 		p.decrWaitsAndIncrRecvs()
 	}(ch)
-	return NewErrResult(ctx.Err())
+	return newErrResult(ctx.Err())
 }
 
 func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 	resp := resultsp.Get(len(multi), len(multi))
 	if err := ctx.Err(); err != nil {
 		for i := 0; i < len(resp.s); i++ {
-			resp.s[i] = NewErrResult(err)
+			resp.s[i] = newErrResult(err)
 		}
 		return resp
 	}
@@ -1117,7 +1117,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 	if p.version < 6 && noReply != 0 {
 		if noReply != len(multi) {
 			for i := 0; i < len(resp.s); i++ {
-				resp.s[i] = NewErrResult(ErrRESP2PubSubMixed)
+				resp.s[i] = newErrResult(ErrRESP2PubSubMixed)
 			}
 			return resp
 		} else if p.r2p != nil {
@@ -1130,7 +1130,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 		if cmd.IsBlock() {
 			if noReply != 0 {
 				for i := 0; i < len(resp.s); i++ {
-					resp.s[i] = NewErrResult(ErrBlockingPubSubMixed)
+					resp.s[i] = newErrResult(ErrBlockingPubSubMixed)
 				}
 				return resp
 			}
@@ -1169,7 +1169,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 		}
 		p.syncDoMulti(dl, ok, resp.s, multi)
 	} else {
-		err := NewErrResult(p.Error())
+		err := newErrResult(p.Error())
 		for i := 0; i < len(resp.s); i++ {
 			resp.s[i] = err
 		}
@@ -1183,7 +1183,7 @@ queue:
 	ch, err := p.queue.PutMulti(ctx, multi, resp.s)
 	if err != nil {
 		p.decrWaits()
-		errResult := NewErrResult(err)
+		errResult := newErrResult(err)
 		for i := 0; i < len(resp.s); i++ {
 			resp.s[i] = errResult
 		}
@@ -1208,7 +1208,7 @@ abort:
 		p.decrWaitsAndIncrRecvs()
 	}(resp, ch)
 	resp = resultsp.Get(len(multi), len(multi))
-	errResult := NewErrResult(ctx.Err())
+	errResult := newErrResult(ctx.Err())
 	for i := 0; i < len(resp.s); i++ {
 		resp.s[i] = errResult
 	}
@@ -1401,7 +1401,7 @@ func (p *pipe) syncDo(dl time.Time, dlOk bool, cmd Completed) (resp ValkeyResult
 		p.conn.Close()
 		p.background() // start the background worker to clean up goroutines
 	}
-	return NewResult(msg, err)
+	return newResult(msg, err)
 }
 
 func (p *pipe) syncDoMulti(dl time.Time, dlOk bool, resp []ValkeyResult, multi []Completed) {
@@ -1444,7 +1444,7 @@ process:
 		if msg, err = syncRead(p.r); err != nil {
 			goto abort
 		}
-		resp[i] = NewResult(msg, err)
+		resp[i] = newResult(msg, err)
 	}
 	return
 abort:
@@ -1455,7 +1455,7 @@ abort:
 	p.conn.Close()
 	p.background() // start the background worker to clean up goroutines
 	for i := range resp {
-		resp[i] = NewErrResult(err)
+		resp[i] = newErrResult(err)
 	}
 }
 
@@ -1490,9 +1490,9 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Va
 	ck, cc := cmds.CacheKey(cmd)
 	now := time.Now()
 	if v, entry := p.cache.Flight(ck, cc, ttl, now); v.typ != 0 {
-		return NewResult(v, nil)
+		return newResult(v, nil)
 	} else if entry != nil {
-		return NewResult(entry.Wait(ctx))
+		return newResult(entry.Wait(ctx))
 	}
 	if cmds.IsStaticTTL(Completed(cmd)) {
 		// Wire: [OPT_IN, cmd]. The read goroutine resolves the Flight
@@ -1526,9 +1526,9 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Va
 			}
 		}
 		p.cache.Cancel(ck, cc, err)
-		return NewErrResult(err)
+		return newErrResult(err)
 	}
-	return NewResult(exec[1], nil)
+	return newResult(exec[1], nil)
 }
 
 func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration) ValkeyResult {
@@ -1598,7 +1598,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 			for _, key := range rewritten.Commands()[1 : keys+1] {
 				p.cache.Cancel(key, mgetcc, err)
 			}
-			return NewErrResult(err)
+			return newErrResult(err)
 		}
 		defer func() {
 			for _, cmd := range multi[2 : len(multi)-1] {
@@ -1607,7 +1607,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 		}()
 		last := len(exec) - 1
 		if len(rewritten.Commands()) == len(commands) { // all cache misses
-			return NewResult(exec[last], nil)
+			return newResult(exec[last], nil)
 		}
 		partial = exec[last].values()
 	} else { // all cache hit
@@ -1620,7 +1620,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 	for i, entry := range entries.e {
 		v, err := entry.Wait(ctx)
 		if err != nil {
-			return NewErrResult(err)
+			return newErrResult(err)
 		}
 		result.val.values()[i] = v
 	}
@@ -1686,7 +1686,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 			ck, cc := cmds.CacheKey(ct.Cmd)
 			v, entry := p.cache.Flight(ck, cc, ct.TTL, now)
 			if v.typ != 0 { // cache hit for one key
-				results.s[i] = NewResult(v, nil)
+				results.s[i] = newResult(v, nil)
 				continue
 			}
 			if entry != nil {
@@ -1737,7 +1737,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 	}
 
 	for i, entry := range entries.e {
-		results.s[i] = NewResult(entry.Wait(ctx))
+		results.s[i] = newResult(entry.Wait(ctx))
 	}
 
 	if len(missing) == 0 {
@@ -1774,9 +1774,9 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 							}
 						}
 					}
-					results.s[j] = NewErrResult(err)
+					results.s[j] = newErrResult(err)
 				} else {
-					results.s[j] = NewResult(exec[len(exec)-1], nil)
+					results.s[j] = newResult(exec[len(exec)-1], nil)
 				}
 				break
 			}

--- a/pipe.go
+++ b/pipe.go
@@ -1268,7 +1268,7 @@ func (p *pipe) DoStream(ctx context.Context, pool *pool, cmd Completed) ValkeyRe
 	cmds.CompletedCS(cmd).Verify()
 
 	if err := ctx.Err(); err != nil {
-		return ValkeyResultStream{e: err}
+		return NewErrorResultStream(err)
 	}
 
 	state := atomic.LoadInt32(&p.state)
@@ -1309,7 +1309,7 @@ func (p *pipe) DoStream(ctx context.Context, pool *pool, cmd Completed) ValkeyRe
 	atomic.AddInt32(&p.blcksig, -1)
 	p.decrWaits()
 	pool.Store(p)
-	return ValkeyResultStream{e: p.Error()}
+	return NewErrorResultStream(p.Error())
 }
 
 func (p *pipe) DoMultiStream(ctx context.Context, pool *pool, multi ...Completed) MultiValkeyResultStream {
@@ -1318,7 +1318,7 @@ func (p *pipe) DoMultiStream(ctx context.Context, pool *pool, multi ...Completed
 	}
 
 	if err := ctx.Err(); err != nil {
-		return ValkeyResultStream{e: err}
+		return NewErrorResultStream(err)
 	}
 
 	state := atomic.LoadInt32(&p.state)
@@ -1374,7 +1374,7 @@ func (p *pipe) DoMultiStream(ctx context.Context, pool *pool, multi ...Completed
 	atomic.AddInt32(&p.blcksig, -1)
 	p.decrWaits()
 	pool.Store(p)
-	return ValkeyResultStream{e: p.Error()}
+	return NewErrorResultStream(p.Error())
 }
 
 func (p *pipe) syncDo(dl time.Time, dlOk bool, cmd Completed) (resp ValkeyResult) {

--- a/pipe.go
+++ b/pipe.go
@@ -460,7 +460,7 @@ func (p *pipe) _background() {
 		old.hooks.onInvalidations(nil)
 	}
 
-	resp := newErrResult(err)
+	resp := NewErrorResult(err)
 	for p.loadWaits() != 0 {
 		select {
 		case <-p.close: // p.queue.NextWriteCmd() can only be called after _backgroundWrite
@@ -548,9 +548,9 @@ func (p *pipe) _backgroundRead() (err error) {
 	)
 
 	defer func() {
-		resp := newErrResult(err)
+		resp := NewErrorResult(err)
 		if e := p.Error(); e == errConnExpired {
-			resp = newErrResult(e)
+			resp = NewErrorResult(e)
 		}
 		if err != nil && ff < len(multi) {
 			for ; ff < len(resps); ff++ {
@@ -1020,7 +1020,7 @@ func (p *pipe) AZ() string {
 
 func (p *pipe) Do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 	if err := ctx.Err(); err != nil {
-		return newErrResult(err)
+		return NewErrorResult(err)
 	}
 
 	cmds.CompletedCS(cmd).Verify()
@@ -1060,7 +1060,7 @@ func (p *pipe) Do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 		}
 		resp = p.syncDo(dl, ok, cmd)
 	} else {
-		resp = newErrResult(p.Error())
+		resp = NewErrorResult(p.Error())
 	}
 
 	if left := p.decrWaitsAndIncrRecvs(); state == 0 && left != 0 {
@@ -1072,7 +1072,7 @@ queue:
 	ch, err := p.queue.PutOne(ctx, cmd)
 	if err != nil {
 		p.decrWaits()
-		return newErrResult(err)
+		return NewErrorResult(err)
 	}
 
 	if ctxCh := ctx.Done(); ctxCh == nil {
@@ -1091,14 +1091,14 @@ abort:
 		<-ch
 		p.decrWaitsAndIncrRecvs()
 	}(ch)
-	return newErrResult(ctx.Err())
+	return NewErrorResult(ctx.Err())
 }
 
 func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 	resp := resultsp.Get(len(multi), len(multi))
 	if err := ctx.Err(); err != nil {
 		for i := 0; i < len(resp.s); i++ {
-			resp.s[i] = newErrResult(err)
+			resp.s[i] = NewErrorResult(err)
 		}
 		return resp
 	}
@@ -1117,7 +1117,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 	if p.version < 6 && noReply != 0 {
 		if noReply != len(multi) {
 			for i := 0; i < len(resp.s); i++ {
-				resp.s[i] = newErrResult(ErrRESP2PubSubMixed)
+				resp.s[i] = NewErrorResult(ErrRESP2PubSubMixed)
 			}
 			return resp
 		} else if p.r2p != nil {
@@ -1130,7 +1130,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 		if cmd.IsBlock() {
 			if noReply != 0 {
 				for i := 0; i < len(resp.s); i++ {
-					resp.s[i] = newErrResult(ErrBlockingPubSubMixed)
+					resp.s[i] = NewErrorResult(ErrBlockingPubSubMixed)
 				}
 				return resp
 			}
@@ -1169,7 +1169,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 		}
 		p.syncDoMulti(dl, ok, resp.s, multi)
 	} else {
-		err := newErrResult(p.Error())
+		err := NewErrorResult(p.Error())
 		for i := 0; i < len(resp.s); i++ {
 			resp.s[i] = err
 		}
@@ -1183,7 +1183,7 @@ queue:
 	ch, err := p.queue.PutMulti(ctx, multi, resp.s)
 	if err != nil {
 		p.decrWaits()
-		errResult := newErrResult(err)
+		errResult := NewErrorResult(err)
 		for i := 0; i < len(resp.s); i++ {
 			resp.s[i] = errResult
 		}
@@ -1208,7 +1208,7 @@ abort:
 		p.decrWaitsAndIncrRecvs()
 	}(resp, ch)
 	resp = resultsp.Get(len(multi), len(multi))
-	errResult := newErrResult(ctx.Err())
+	errResult := NewErrorResult(ctx.Err())
 	for i := 0; i < len(resp.s); i++ {
 		resp.s[i] = errResult
 	}
@@ -1216,6 +1216,11 @@ abort:
 }
 
 type MultiValkeyResultStream = ValkeyResultStream
+
+// NewErrorResultStream returns a ValkeyResultStream with the specified error. Useful for implementing hooks or mocking.
+func NewErrorResultStream(err error) ValkeyResultStream {
+	return ValkeyResultStream{e: err}
+}
 
 type ValkeyResultStream struct {
 	p *pool
@@ -1455,7 +1460,7 @@ abort:
 	p.conn.Close()
 	p.background() // start the background worker to clean up goroutines
 	for i := range resp {
-		resp[i] = newErrResult(err)
+		resp[i] = NewErrorResult(err)
 	}
 }
 
@@ -1526,7 +1531,7 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Va
 			}
 		}
 		p.cache.Cancel(ck, cc, err)
-		return newErrResult(err)
+		return NewErrorResult(err)
 	}
 	return newResult(exec[1], nil)
 }
@@ -1598,7 +1603,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 			for _, key := range rewritten.Commands()[1 : keys+1] {
 				p.cache.Cancel(key, mgetcc, err)
 			}
-			return newErrResult(err)
+			return NewErrorResult(err)
 		}
 		defer func() {
 			for _, cmd := range multi[2 : len(multi)-1] {
@@ -1620,7 +1625,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 	for i, entry := range entries.e {
 		v, err := entry.Wait(ctx)
 		if err != nil {
-			return newErrResult(err)
+			return NewErrorResult(err)
 		}
 		result.val.values()[i] = v
 	}
@@ -1774,7 +1779,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 							}
 						}
 					}
-					results.s[j] = newErrResult(err)
+					results.s[j] = NewErrorResult(err)
 				} else {
 					results.s[j] = newResult(exec[len(exec)-1], nil)
 				}

--- a/pipe.go
+++ b/pipe.go
@@ -460,7 +460,7 @@ func (p *pipe) _background() {
 		old.hooks.onInvalidations(nil)
 	}
 
-	resp := newErrResult(err)
+	resp := NewErrResult(err)
 	for p.loadWaits() != 0 {
 		select {
 		case <-p.close: // p.queue.NextWriteCmd() can only be called after _backgroundWrite
@@ -548,9 +548,9 @@ func (p *pipe) _backgroundRead() (err error) {
 	)
 
 	defer func() {
-		resp := newErrResult(err)
+		resp := NewErrResult(err)
 		if e := p.Error(); e == errConnExpired {
-			resp = newErrResult(e)
+			resp = NewErrResult(e)
 		}
 		if err != nil && ff < len(multi) {
 			for ; ff < len(resps); ff++ {
@@ -693,7 +693,7 @@ func (p *pipe) _backgroundRead() (err error) {
 			skipUnsubReply = false
 			continue
 		}
-		resp := newResult(msg, err)
+		resp := NewResult(msg, err)
 		if resps != nil {
 			resps[ff] = resp
 		}
@@ -1020,7 +1020,7 @@ func (p *pipe) AZ() string {
 
 func (p *pipe) Do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 	if err := ctx.Err(); err != nil {
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 
 	cmds.CompletedCS(cmd).Verify()
@@ -1060,7 +1060,7 @@ func (p *pipe) Do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 		}
 		resp = p.syncDo(dl, ok, cmd)
 	} else {
-		resp = newErrResult(p.Error())
+		resp = NewErrResult(p.Error())
 	}
 
 	if left := p.decrWaitsAndIncrRecvs(); state == 0 && left != 0 {
@@ -1072,7 +1072,7 @@ queue:
 	ch, err := p.queue.PutOne(ctx, cmd)
 	if err != nil {
 		p.decrWaits()
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 
 	if ctxCh := ctx.Done(); ctxCh == nil {
@@ -1091,14 +1091,14 @@ abort:
 		<-ch
 		p.decrWaitsAndIncrRecvs()
 	}(ch)
-	return newErrResult(ctx.Err())
+	return NewErrResult(ctx.Err())
 }
 
 func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 	resp := resultsp.Get(len(multi), len(multi))
 	if err := ctx.Err(); err != nil {
 		for i := 0; i < len(resp.s); i++ {
-			resp.s[i] = newErrResult(err)
+			resp.s[i] = NewErrResult(err)
 		}
 		return resp
 	}
@@ -1117,7 +1117,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 	if p.version < 6 && noReply != 0 {
 		if noReply != len(multi) {
 			for i := 0; i < len(resp.s); i++ {
-				resp.s[i] = newErrResult(ErrRESP2PubSubMixed)
+				resp.s[i] = NewErrResult(ErrRESP2PubSubMixed)
 			}
 			return resp
 		} else if p.r2p != nil {
@@ -1130,7 +1130,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 		if cmd.IsBlock() {
 			if noReply != 0 {
 				for i := 0; i < len(resp.s); i++ {
-					resp.s[i] = newErrResult(ErrBlockingPubSubMixed)
+					resp.s[i] = NewErrResult(ErrBlockingPubSubMixed)
 				}
 				return resp
 			}
@@ -1169,7 +1169,7 @@ func (p *pipe) DoMulti(ctx context.Context, multi ...Completed) *valkeyresults {
 		}
 		p.syncDoMulti(dl, ok, resp.s, multi)
 	} else {
-		err := newErrResult(p.Error())
+		err := NewErrResult(p.Error())
 		for i := 0; i < len(resp.s); i++ {
 			resp.s[i] = err
 		}
@@ -1183,7 +1183,7 @@ queue:
 	ch, err := p.queue.PutMulti(ctx, multi, resp.s)
 	if err != nil {
 		p.decrWaits()
-		errResult := newErrResult(err)
+		errResult := NewErrResult(err)
 		for i := 0; i < len(resp.s); i++ {
 			resp.s[i] = errResult
 		}
@@ -1208,7 +1208,7 @@ abort:
 		p.decrWaitsAndIncrRecvs()
 	}(resp, ch)
 	resp = resultsp.Get(len(multi), len(multi))
-	errResult := newErrResult(ctx.Err())
+	errResult := NewErrResult(ctx.Err())
 	for i := 0; i < len(resp.s); i++ {
 		resp.s[i] = errResult
 	}
@@ -1401,7 +1401,7 @@ func (p *pipe) syncDo(dl time.Time, dlOk bool, cmd Completed) (resp ValkeyResult
 		p.conn.Close()
 		p.background() // start the background worker to clean up goroutines
 	}
-	return newResult(msg, err)
+	return NewResult(msg, err)
 }
 
 func (p *pipe) syncDoMulti(dl time.Time, dlOk bool, resp []ValkeyResult, multi []Completed) {
@@ -1444,7 +1444,7 @@ process:
 		if msg, err = syncRead(p.r); err != nil {
 			goto abort
 		}
-		resp[i] = newResult(msg, err)
+		resp[i] = NewResult(msg, err)
 	}
 	return
 abort:
@@ -1455,7 +1455,7 @@ abort:
 	p.conn.Close()
 	p.background() // start the background worker to clean up goroutines
 	for i := range resp {
-		resp[i] = newErrResult(err)
+		resp[i] = NewErrResult(err)
 	}
 }
 
@@ -1490,9 +1490,9 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Va
 	ck, cc := cmds.CacheKey(cmd)
 	now := time.Now()
 	if v, entry := p.cache.Flight(ck, cc, ttl, now); v.typ != 0 {
-		return newResult(v, nil)
+		return NewResult(v, nil)
 	} else if entry != nil {
-		return newResult(entry.Wait(ctx))
+		return NewResult(entry.Wait(ctx))
 	}
 	if cmds.IsStaticTTL(Completed(cmd)) {
 		// Wire: [OPT_IN, cmd]. The read goroutine resolves the Flight
@@ -1526,9 +1526,9 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Va
 			}
 		}
 		p.cache.Cancel(ck, cc, err)
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
-	return newResult(exec[1], nil)
+	return NewResult(exec[1], nil)
 }
 
 func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration) ValkeyResult {
@@ -1598,7 +1598,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 			for _, key := range rewritten.Commands()[1 : keys+1] {
 				p.cache.Cancel(key, mgetcc, err)
 			}
-			return newErrResult(err)
+			return NewErrResult(err)
 		}
 		defer func() {
 			for _, cmd := range multi[2 : len(multi)-1] {
@@ -1607,7 +1607,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 		}()
 		last := len(exec) - 1
 		if len(rewritten.Commands()) == len(commands) { // all cache misses
-			return newResult(exec[last], nil)
+			return NewResult(exec[last], nil)
 		}
 		partial = exec[last].values()
 	} else { // all cache hit
@@ -1620,7 +1620,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 	for i, entry := range entries.e {
 		v, err := entry.Wait(ctx)
 		if err != nil {
-			return newErrResult(err)
+			return NewErrResult(err)
 		}
 		result.val.values()[i] = v
 	}
@@ -1686,7 +1686,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 			ck, cc := cmds.CacheKey(ct.Cmd)
 			v, entry := p.cache.Flight(ck, cc, ct.TTL, now)
 			if v.typ != 0 { // cache hit for one key
-				results.s[i] = newResult(v, nil)
+				results.s[i] = NewResult(v, nil)
 				continue
 			}
 			if entry != nil {
@@ -1737,7 +1737,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 	}
 
 	for i, entry := range entries.e {
-		results.s[i] = newResult(entry.Wait(ctx))
+		results.s[i] = NewResult(entry.Wait(ctx))
 	}
 
 	if len(missing) == 0 {
@@ -1774,9 +1774,9 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 							}
 						}
 					}
-					results.s[j] = newErrResult(err)
+					results.s[j] = NewErrResult(err)
 				} else {
-					results.s[j] = newResult(exec[len(exec)-1], nil)
+					results.s[j] = NewResult(exec[len(exec)-1], nil)
 				}
 				break
 			}

--- a/pipe.go
+++ b/pipe.go
@@ -693,7 +693,7 @@ func (p *pipe) _backgroundRead() (err error) {
 			skipUnsubReply = false
 			continue
 		}
-		resp := newResult(msg, err)
+		resp := NewResult(msg, err)
 		if resps != nil {
 			resps[ff] = resp
 		}
@@ -1406,7 +1406,7 @@ func (p *pipe) syncDo(dl time.Time, dlOk bool, cmd Completed) (resp ValkeyResult
 		p.conn.Close()
 		p.background() // start the background worker to clean up goroutines
 	}
-	return newResult(msg, err)
+	return NewResult(msg, err)
 }
 
 func (p *pipe) syncDoMulti(dl time.Time, dlOk bool, resp []ValkeyResult, multi []Completed) {
@@ -1449,7 +1449,7 @@ process:
 		if msg, err = syncRead(p.r); err != nil {
 			goto abort
 		}
-		resp[i] = newResult(msg, err)
+		resp[i] = NewResult(msg, err)
 	}
 	return
 abort:
@@ -1495,9 +1495,9 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Va
 	ck, cc := cmds.CacheKey(cmd)
 	now := time.Now()
 	if v, entry := p.cache.Flight(ck, cc, ttl, now); v.typ != 0 {
-		return newResult(v, nil)
+		return NewResult(v, nil)
 	} else if entry != nil {
-		return newResult(entry.Wait(ctx))
+		return NewResult(entry.Wait(ctx))
 	}
 	if cmds.IsStaticTTL(Completed(cmd)) {
 		// Wire: [OPT_IN, cmd]. The read goroutine resolves the Flight
@@ -1533,7 +1533,7 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Va
 		p.cache.Cancel(ck, cc, err)
 		return NewErrorResult(err)
 	}
-	return newResult(exec[1], nil)
+	return NewResult(exec[1], nil)
 }
 
 func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration) ValkeyResult {
@@ -1612,7 +1612,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 		}()
 		last := len(exec) - 1
 		if len(rewritten.Commands()) == len(commands) { // all cache misses
-			return newResult(exec[last], nil)
+			return NewResult(exec[last], nil)
 		}
 		partial = exec[last].values()
 	} else { // all cache hit
@@ -1691,7 +1691,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 			ck, cc := cmds.CacheKey(ct.Cmd)
 			v, entry := p.cache.Flight(ck, cc, ct.TTL, now)
 			if v.typ != 0 { // cache hit for one key
-				results.s[i] = newResult(v, nil)
+				results.s[i] = NewResult(v, nil)
 				continue
 			}
 			if entry != nil {
@@ -1742,7 +1742,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 	}
 
 	for i, entry := range entries.e {
-		results.s[i] = newResult(entry.Wait(ctx))
+		results.s[i] = NewResult(entry.Wait(ctx))
 	}
 
 	if len(missing) == 0 {
@@ -1781,7 +1781,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *valkeyr
 					}
 					results.s[j] = NewErrorResult(err)
 				} else {
-					results.s[j] = newResult(exec[len(exec)-1], nil)
+					results.s[j] = NewResult(exec[len(exec)-1], nil)
 				}
 				break
 			}

--- a/sentinel.go
+++ b/sentinel.go
@@ -263,6 +263,7 @@ func (c *sentinelClient) DoStream(ctx context.Context, cmd Completed) ValkeyResu
 func (c *sentinelClient) DoMultiStream(ctx context.Context, multi ...Completed) MultiValkeyResultStream {
 	if len(multi) == 0 {
 		return ValkeyResultStream{e: io.EOF}
+		return NewErrorResultStream(io.EOF)
 	}
 
 	cc := c.pickMulti(c.sendAllToReplica(multi))

--- a/sentinel.go
+++ b/sentinel.go
@@ -262,7 +262,6 @@ func (c *sentinelClient) DoStream(ctx context.Context, cmd Completed) ValkeyResu
 
 func (c *sentinelClient) DoMultiStream(ctx context.Context, multi ...Completed) MultiValkeyResultStream {
 	if len(multi) == 0 {
-		return ValkeyResultStream{e: io.EOF}
 		return NewErrorResultStream(io.EOF)
 	}
 

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -43,7 +43,7 @@ func TestSentinelClientInit(t *testing.T) {
 			&ClientOption{InitAddress: []string{":0"}},
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
-					DoMultiFn: func(cmd ...Completed) *valkeyresults { return &valkeyresults{s: []ValkeyResult{newErrResult(v)}} },
+					DoMultiFn: func(cmd ...Completed) *valkeyresults { return &valkeyresults{s: []ValkeyResult{NewErrorResult(v)}} },
 				}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -58,8 +58,8 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} },
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				return &valkeyresults{s: []ValkeyResult{
-					newErrResult(v),
-					newErrResult(v),
+					NewErrorResult(v),
+					NewErrorResult(v),
 				}}
 			},
 		}
@@ -73,7 +73,7 @@ func TestSentinelClientInit(t *testing.T) {
 							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					newErrResult(v),
+					NewErrorResult(v),
 				}}
 			},
 		}
@@ -184,8 +184,8 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} },
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				return &valkeyresults{s: []ValkeyResult{
-					newErrResult(v),
-					newErrResult(v),
+					NewErrorResult(v),
+					NewErrorResult(v),
 				}}
 			},
 		}
@@ -199,7 +199,7 @@ func TestSentinelClientInit(t *testing.T) {
 							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					newErrResult(v),
+					NewErrorResult(v),
 				}}
 			},
 		}
@@ -446,7 +446,7 @@ func TestSentinelClientInit(t *testing.T) {
 				}
 				if dst == ":2" {
 					return &mockConn{
-						DoFn: func(cmd Completed) ValkeyResult { return newErrResult(v) },
+						DoFn: func(cmd Completed) ValkeyResult { return NewErrorResult(v) },
 					}
 				}
 				if dst == ":3" {
@@ -480,7 +480,7 @@ func TestSentinelClientInit(t *testing.T) {
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrorResult(errors.New("die"))
 				}
 				return ValkeyResult{}
 			},
@@ -542,7 +542,7 @@ func TestSentinelClientInit(t *testing.T) {
 		r3 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrorResult(errors.New("die"))
 				}
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 			},
@@ -709,7 +709,7 @@ func TestSentinelClientInit(t *testing.T) {
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrorResult(errors.New("die"))
 				}
 				return ValkeyResult{}
 			},
@@ -821,7 +821,7 @@ func TestSentinelClientInit(t *testing.T) {
 		r1 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrorResult(errors.New("die"))
 				}
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "slave")})}
 			},
@@ -980,7 +980,7 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 					})},
 				}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newErrResult(ErrClosing), newErrResult(ErrClosing)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(ErrClosing), NewErrorResult(ErrClosing)}}
 		},
 	}
 	m := &mockConn{
@@ -1030,7 +1030,7 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 				first = false
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 			}
-			return newErrResult(ErrClosing)
+			return NewErrorResult(ErrClosing)
 		},
 	}
 	client, err := newSentinelClient(
@@ -1409,15 +1409,15 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 					return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 				}
 				atomic.AddUint32(&retry, 1)
-				return newErrResult(ErrClosing)
+				return NewErrorResult(ErrClosing)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				atomic.AddUint32(&retry, 1)
-				return &valkeyresults{s: []ValkeyResult{newErrResult(ErrClosing)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(ErrClosing)}}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				atomic.AddUint32(&retry, 1)
-				return newErrResult(ErrClosing)
+				return NewErrorResult(ErrClosing)
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				atomic.AddUint32(&retry, 1)
@@ -1585,7 +1585,7 @@ func TestSentinelClientPubSub(t *testing.T) {
 	}
 	s3 := &mockConn{
 		DoMultiFn: func(cmd ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errClosing)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(errClosing)}}
 		},
 	}
 	m4 := &mockConn{
@@ -1755,7 +1755,7 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	}
 	s3 := &mockConn{
 		DoMultiFn: func(cmd ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errClosing)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(errClosing)}}
 		},
 	}
 	slave4 := &mockConn{
@@ -2163,7 +2163,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrorResult(errConnExpired)
 			}
 			return newResult(strmsg('+', "OK"), nil)
 		}
@@ -2177,7 +2177,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrorResult(errConnExpired)
 			}
 			return newResult(strmsg('+', "OK"), nil)
 		}
@@ -2191,7 +2191,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -2205,7 +2205,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -2230,14 +2230,14 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi Command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
@@ -2246,7 +2246,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
@@ -2256,7 +2256,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 					newResult(strmsg('+', "OK"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
 					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
@@ -2269,7 +2269,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
@@ -2315,7 +2315,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -2329,7 +2329,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -43,7 +43,7 @@ func TestSentinelClientInit(t *testing.T) {
 			&ClientOption{InitAddress: []string{":0"}},
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
-					DoMultiFn: func(cmd ...Completed) *valkeyresults { return &valkeyresults{s: []ValkeyResult{NewErrResult(v)}} },
+					DoMultiFn: func(cmd ...Completed) *valkeyresults { return &valkeyresults{s: []ValkeyResult{newErrResult(v)}} },
 				}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -58,8 +58,8 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} },
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				return &valkeyresults{s: []ValkeyResult{
-					NewErrResult(v),
-					NewErrResult(v),
+					newErrResult(v),
+					newErrResult(v),
 				}}
 			},
 		}
@@ -73,7 +73,7 @@ func TestSentinelClientInit(t *testing.T) {
 							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					NewErrResult(v),
+					newErrResult(v),
 				}}
 			},
 		}
@@ -184,8 +184,8 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} },
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				return &valkeyresults{s: []ValkeyResult{
-					NewErrResult(v),
-					NewErrResult(v),
+					newErrResult(v),
+					newErrResult(v),
 				}}
 			},
 		}
@@ -199,7 +199,7 @@ func TestSentinelClientInit(t *testing.T) {
 							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					NewErrResult(v),
+					newErrResult(v),
 				}}
 			},
 		}
@@ -446,7 +446,7 @@ func TestSentinelClientInit(t *testing.T) {
 				}
 				if dst == ":2" {
 					return &mockConn{
-						DoFn: func(cmd Completed) ValkeyResult { return NewErrResult(v) },
+						DoFn: func(cmd Completed) ValkeyResult { return newErrResult(v) },
 					}
 				}
 				if dst == ":3" {
@@ -480,7 +480,7 @@ func TestSentinelClientInit(t *testing.T) {
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return NewErrResult(errors.New("die"))
+					return newErrResult(errors.New("die"))
 				}
 				return ValkeyResult{}
 			},
@@ -542,7 +542,7 @@ func TestSentinelClientInit(t *testing.T) {
 		r3 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return NewErrResult(errors.New("die"))
+					return newErrResult(errors.New("die"))
 				}
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 			},
@@ -709,7 +709,7 @@ func TestSentinelClientInit(t *testing.T) {
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return NewErrResult(errors.New("die"))
+					return newErrResult(errors.New("die"))
 				}
 				return ValkeyResult{}
 			},
@@ -821,7 +821,7 @@ func TestSentinelClientInit(t *testing.T) {
 		r1 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return NewErrResult(errors.New("die"))
+					return newErrResult(errors.New("die"))
 				}
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "slave")})}
 			},
@@ -980,7 +980,7 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 					})},
 				}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(ErrClosing), NewErrResult(ErrClosing)}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(ErrClosing), newErrResult(ErrClosing)}}
 		},
 	}
 	m := &mockConn{
@@ -1030,7 +1030,7 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 				first = false
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 			}
-			return NewErrResult(ErrClosing)
+			return newErrResult(ErrClosing)
 		},
 	}
 	client, err := newSentinelClient(
@@ -1120,7 +1120,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				NewResult(strmsg('+', "master"), nil),
+				newResult(strmsg('+', "master"), nil),
 			}}
 		}
 
@@ -1155,7 +1155,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return NewResult(strmsg('+', "Do"), nil)
+			return newResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1178,7 +1178,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Do"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -1207,7 +1207,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return NewResult(strmsg('+', "DoCache"), nil)
+			return newResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1220,7 +1220,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "DoCache"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -1276,10 +1276,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicated Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1325,10 +1325,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicate Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1409,15 +1409,15 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 					return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 				}
 				atomic.AddUint32(&retry, 1)
-				return NewErrResult(ErrClosing)
+				return newErrResult(ErrClosing)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				atomic.AddUint32(&retry, 1)
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(ErrClosing)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(ErrClosing)}}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				atomic.AddUint32(&retry, 1)
-				return NewErrResult(ErrClosing)
+				return newErrResult(ErrClosing)
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				atomic.AddUint32(&retry, 1)
@@ -1585,7 +1585,7 @@ func TestSentinelClientPubSub(t *testing.T) {
 	}
 	s3 := &mockConn{
 		DoMultiFn: func(cmd ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(errClosing)}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(errClosing)}}
 		},
 	}
 	m4 := &mockConn{
@@ -1755,7 +1755,7 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	}
 	s3 := &mockConn{
 		DoMultiFn: func(cmd ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(errClosing)}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(errClosing)}}
 		},
 	}
 	slave4 := &mockConn{
@@ -1967,9 +1967,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1989,9 +1989,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "ERR some other error"), nil)
+				return newResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -2008,9 +2008,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -2029,9 +2029,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -2046,9 +2046,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -2070,9 +2070,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoFn: m1.DoFn} }
 
@@ -2093,9 +2093,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoMultiFn: m1.DoMultiFn} }
 
@@ -2163,9 +2163,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return NewErrResult(errConnExpired)
+				return newErrResult(errConnExpired)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Get().Key("Do").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2177,9 +2177,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return NewErrResult(errConnExpired)
+				return newErrResult(errConnExpired)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2191,9 +2191,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2205,9 +2205,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -2230,53 +2230,53 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi Command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "1"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "1"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(strmsg('+', "QUEUE"), nil),
-					NewResult(slicemsg('*', []ValkeyMessage{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					NewErrResult(errConnExpired),
+					newErrResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -2315,9 +2315,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2329,9 +2329,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {
@@ -2574,7 +2574,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return NewResult(strmsg('+', "Do"), nil)
+			return newResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2590,7 +2590,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return NewResult(strmsg('+', "Do"), nil)
+			return newResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2619,7 +2619,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 								t.Fatalf("unexpected command %v", cmd)
 							}
 
-							return NewResult(strmsg('+', "DoCache"), nil)
+							return newResult(strmsg('+', "DoCache"), nil)
 						},
 					}
 				}
@@ -2654,7 +2654,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return NewResult(strmsg('+', "DoCache"), nil)
+			return newResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2706,8 +2706,8 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					NewResult(strmsg('+', "DoMulti"), nil),
-					NewResult(strmsg('+', "value2"), nil),
+					newResult(strmsg('+', "DoMulti"), nil),
+					newResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -2734,7 +2734,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd[1])
 			}
 			return &valkeyresults{
-				s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
+				s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
 			}
 		}
 		resps := client.DoMulti(context.Background(), c1, c2)
@@ -2803,7 +2803,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 								t.Fatalf("unexpected command %v, %v", multi[1].Cmd, multi[1].TTL)
 							}
 							return &valkeyresults{
-								s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
+								s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
 							}
 						},
 					}
@@ -2850,8 +2850,8 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					NewResult(strmsg('+', "value1"), nil),
-					NewResult(strmsg('+', "value2"), nil),
+					newResult(strmsg('+', "value1"), nil),
+					newResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -2945,10 +2945,10 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -3132,7 +3132,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return NewResult(strmsg('+', "Do"), nil)
+			return newResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -3148,7 +3148,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return NewResult(strmsg('+', "DoCache"), nil)
+			return newResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -3184,7 +3184,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd[1])
 			}
 			return &valkeyresults{
-				s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
+				s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
 			}
 		}
 		resps := client.DoMulti(context.Background(), c1, c2)
@@ -3227,8 +3227,8 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					NewResult(strmsg('+', "value1"), nil),
-					NewResult(strmsg('+', "value2"), nil),
+					newResult(strmsg('+', "value1"), nil),
+					newResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -3273,10 +3273,10 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -3325,10 +3325,10 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -43,7 +43,7 @@ func TestSentinelClientInit(t *testing.T) {
 			&ClientOption{InitAddress: []string{":0"}},
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
-					DoMultiFn: func(cmd ...Completed) *valkeyresults { return &valkeyresults{s: []ValkeyResult{newErrResult(v)}} },
+					DoMultiFn: func(cmd ...Completed) *valkeyresults { return &valkeyresults{s: []ValkeyResult{NewErrResult(v)}} },
 				}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -58,8 +58,8 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} },
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				return &valkeyresults{s: []ValkeyResult{
-					newErrResult(v),
-					newErrResult(v),
+					NewErrResult(v),
+					NewErrResult(v),
 				}}
 			},
 		}
@@ -73,7 +73,7 @@ func TestSentinelClientInit(t *testing.T) {
 							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					newErrResult(v),
+					NewErrResult(v),
 				}}
 			},
 		}
@@ -184,8 +184,8 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} },
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				return &valkeyresults{s: []ValkeyResult{
-					newErrResult(v),
-					newErrResult(v),
+					NewErrResult(v),
+					NewErrResult(v),
 				}}
 			},
 		}
@@ -199,7 +199,7 @@ func TestSentinelClientInit(t *testing.T) {
 							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					newErrResult(v),
+					NewErrResult(v),
 				}}
 			},
 		}
@@ -446,7 +446,7 @@ func TestSentinelClientInit(t *testing.T) {
 				}
 				if dst == ":2" {
 					return &mockConn{
-						DoFn: func(cmd Completed) ValkeyResult { return newErrResult(v) },
+						DoFn: func(cmd Completed) ValkeyResult { return NewErrResult(v) },
 					}
 				}
 				if dst == ":3" {
@@ -480,7 +480,7 @@ func TestSentinelClientInit(t *testing.T) {
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrResult(errors.New("die"))
 				}
 				return ValkeyResult{}
 			},
@@ -542,7 +542,7 @@ func TestSentinelClientInit(t *testing.T) {
 		r3 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrResult(errors.New("die"))
 				}
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 			},
@@ -709,7 +709,7 @@ func TestSentinelClientInit(t *testing.T) {
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrResult(errors.New("die"))
 				}
 				return ValkeyResult{}
 			},
@@ -821,7 +821,7 @@ func TestSentinelClientInit(t *testing.T) {
 		r1 := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
 				if atomic.LoadInt32(&disconnect) == 1 {
-					return newErrResult(errors.New("die"))
+					return NewErrResult(errors.New("die"))
 				}
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "slave")})}
 			},
@@ -980,7 +980,7 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 					})},
 				}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newErrResult(ErrClosing), newErrResult(ErrClosing)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(ErrClosing), NewErrResult(ErrClosing)}}
 		},
 	}
 	m := &mockConn{
@@ -1030,7 +1030,7 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 				first = false
 				return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 			}
-			return newErrResult(ErrClosing)
+			return NewErrResult(ErrClosing)
 		},
 	}
 	client, err := newSentinelClient(
@@ -1120,7 +1120,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				newResult(strmsg('+', "master"), nil),
+				NewResult(strmsg('+', "master"), nil),
 			}}
 		}
 
@@ -1155,7 +1155,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1178,7 +1178,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Do"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -1207,7 +1207,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1220,7 +1220,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "DoCache"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -1276,10 +1276,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicated Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1325,10 +1325,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicate Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1409,15 +1409,15 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 					return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
 				}
 				atomic.AddUint32(&retry, 1)
-				return newErrResult(ErrClosing)
+				return NewErrResult(ErrClosing)
 			},
 			DoMultiFn: func(multi ...Completed) *valkeyresults {
 				atomic.AddUint32(&retry, 1)
-				return &valkeyresults{s: []ValkeyResult{newErrResult(ErrClosing)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(ErrClosing)}}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 				atomic.AddUint32(&retry, 1)
-				return newErrResult(ErrClosing)
+				return NewErrResult(ErrClosing)
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				atomic.AddUint32(&retry, 1)
@@ -1585,7 +1585,7 @@ func TestSentinelClientPubSub(t *testing.T) {
 	}
 	s3 := &mockConn{
 		DoMultiFn: func(cmd ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errClosing)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(errClosing)}}
 		},
 	}
 	m4 := &mockConn{
@@ -1755,7 +1755,7 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	}
 	s3 := &mockConn{
 		DoMultiFn: func(cmd ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errClosing)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(errClosing)}}
 		},
 	}
 	slave4 := &mockConn{
@@ -1967,9 +1967,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1989,9 +1989,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "ERR some other error"), nil)
+				return NewResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -2008,9 +2008,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -2029,9 +2029,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -2046,9 +2046,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -2070,9 +2070,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoFn: m1.DoFn} }
 
@@ -2093,9 +2093,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoMultiFn: m1.DoMultiFn} }
 
@@ -2163,9 +2163,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoFn = func(cmd Completed) ValkeyResult {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Get().Key("Do").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2177,9 +2177,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2191,9 +2191,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2205,9 +2205,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -2230,53 +2230,53 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 			switch atomic.AddInt64(&attempts, 1) {
 			case 1: // errConnExpired at the head of processing
 				orgMulti = multi
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			case 2: // errConnExpired at Multi Command
 				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "1"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "1"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired), NewErrResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewErrResult(errConnExpired), NewErrResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
-					newErrResult(errConnExpired),
+					NewErrResult(errConnExpired),
 				}}
 			case 6:
 				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -2315,9 +2315,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2329,9 +2329,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {
@@ -2574,7 +2574,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2590,7 +2590,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2619,7 +2619,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 								t.Fatalf("unexpected command %v", cmd)
 							}
 
-							return newResult(strmsg('+', "DoCache"), nil)
+							return NewResult(strmsg('+', "DoCache"), nil)
 						},
 					}
 				}
@@ -2654,7 +2654,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2706,8 +2706,8 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					newResult(strmsg('+', "DoMulti"), nil),
-					newResult(strmsg('+', "value2"), nil),
+					NewResult(strmsg('+', "DoMulti"), nil),
+					NewResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -2734,7 +2734,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd[1])
 			}
 			return &valkeyresults{
-				s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
+				s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
 			}
 		}
 		resps := client.DoMulti(context.Background(), c1, c2)
@@ -2803,7 +2803,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 								t.Fatalf("unexpected command %v, %v", multi[1].Cmd, multi[1].TTL)
 							}
 							return &valkeyresults{
-								s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
+								s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
 							}
 						},
 					}
@@ -2850,8 +2850,8 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					newResult(strmsg('+', "value1"), nil),
-					newResult(strmsg('+', "value2"), nil),
+					NewResult(strmsg('+', "value1"), nil),
+					NewResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -2945,10 +2945,10 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -3132,7 +3132,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -3148,7 +3148,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -3184,7 +3184,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd[1])
 			}
 			return &valkeyresults{
-				s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
+				s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
 			}
 		}
 		resps := client.DoMulti(context.Background(), c1, c2)
@@ -3227,8 +3227,8 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					newResult(strmsg('+', "value1"), nil),
-					newResult(strmsg('+', "value2"), nil),
+					NewResult(strmsg('+', "value1"), nil),
+					NewResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -3273,10 +3273,10 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -3325,10 +3325,10 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -1165,7 +1165,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Delegate DoStream", func(t *testing.T) {
 		c := client.B().Get().Key("Do").Build()
 		m.DoStreamFn = func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{e: errors.New(cmd.Commands()[1])}
+			return NewErrorResultStream(errors.New(cmd.Commands()[1]))
 		}
 		if s := client.DoStream(context.Background(), c); s.Error().Error() != "Do" {
 			t.Fatalf("unexpected response %v", s.Error())
@@ -2667,9 +2667,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 
 		c := client.B().Set().Key("key").Value("value").Build()
 		m.DoStreamFn = func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{
-				e: errors.New("DoStream"),
-			}
+			return NewErrorResultStream(errors.New("DoStream"))
 		}
 		if s := client.DoStream(context.Background(), c); s.Error().Error() != "DoStream" {
 			t.Fatalf("unexpected response %v", s.Error())
@@ -2682,9 +2680,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 
 		c := client.B().Get().Key("Do").Build()
 		r.DoStreamFn = func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{
-				e: errors.New("DoStream"),
-			}
+			return NewErrorResultStream(errors.New("DoStream"))
 		}
 		if s := client.DoStream(context.Background(), c); s.Error().Error() != "DoStream" {
 			t.Fatalf("unexpected response %v", s.Error())
@@ -3161,9 +3157,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 
 		c := client.B().Get().Key("Do").Build()
 		r.DoStreamFn = func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{
-				e: errors.New("DoStream"),
-			}
+			return NewErrorResultStream(errors.New("DoStream"))
 		}
 		if s := client.DoStream(context.Background(), c); s.Error().Error() != "DoStream" {
 			t.Fatalf("unexpected response %v", s.Error())

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -1120,7 +1120,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				newResult(strmsg('+', "master"), nil),
+				NewResult(strmsg('+', "master"), nil),
 			}}
 		}
 
@@ -1155,7 +1155,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1178,7 +1178,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Do"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -1207,7 +1207,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1220,7 +1220,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "DoCache"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -1276,10 +1276,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicated Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1325,10 +1325,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicate Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1967,9 +1967,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1989,9 +1989,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "ERR some other error"), nil)
+				return NewResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -2008,9 +2008,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -2029,9 +2029,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoCacheFn = func(cmd Cacheable, ttl time.Duration) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -2046,9 +2046,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -2070,9 +2070,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
+				return NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoFn: m1.DoFn} }
 
@@ -2093,9 +2093,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('-', "LOADING Valkey is loading the dataset in memory"), nil)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoMultiFn: m1.DoMultiFn} }
 
@@ -2165,7 +2165,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return NewErrorResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Get().Key("Do").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2179,7 +2179,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return NewErrorResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), client.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2193,7 +2193,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2205,9 +2205,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(), client.B().Get().Key("Do").Build(), client.B().Get().Key("Do").Build())
 		if len(resps) != 2 {
@@ -2236,7 +2236,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at the head of processing, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "1"), nil),
+					NewResult(strmsg('+', "1"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 3: // errConnExpired in the middle of transaction block
@@ -2244,8 +2244,8 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired), NewErrorResult(errConnExpired),
 				}}
 			case 4: // errConnExpired at Exec Command
@@ -2253,19 +2253,19 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
 					NewErrorResult(errConnExpired), NewErrorResult(errConnExpired)}}
 			case 5: // errConnExpired at end of processing
 				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
 				}
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(strmsg('+', "QUEUE"), nil),
-					newResult(slicemsg('*', []ValkeyMessage{
+					NewResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(strmsg('+', "QUEUE"), nil),
+					NewResult(slicemsg('*', []ValkeyMessage{
 						strmsg('+', "2"),
 						strmsg('+', "3"),
 					}), nil),
@@ -2276,7 +2276,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
 				}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "4"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "4"), nil)}}
 		}
 		multi := []Completed{
 			client.B().Get().Key("1{t}").Build(),
@@ -2317,7 +2317,7 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 			if atomic.AddInt64(&attempts, 1) == 1 {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		if v, err := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2329,9 +2329,9 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		var attempts int64
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *valkeyresults {
 			if atomic.AddInt64(&attempts, 1) == 1 {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil), NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("Do").Cache(), 0), CT(client.B().Get().Key("Do").Cache(), 0))
 		if len(resps) != 2 {
@@ -2574,7 +2574,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2590,7 +2590,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2619,7 +2619,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 								t.Fatalf("unexpected command %v", cmd)
 							}
 
-							return newResult(strmsg('+', "DoCache"), nil)
+							return NewResult(strmsg('+', "DoCache"), nil)
 						},
 					}
 				}
@@ -2654,7 +2654,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -2702,8 +2702,8 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					newResult(strmsg('+', "DoMulti"), nil),
-					newResult(strmsg('+', "value2"), nil),
+					NewResult(strmsg('+', "DoMulti"), nil),
+					NewResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -2730,7 +2730,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd[1])
 			}
 			return &valkeyresults{
-				s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
+				s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
 			}
 		}
 		resps := client.DoMulti(context.Background(), c1, c2)
@@ -2799,7 +2799,7 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 								t.Fatalf("unexpected command %v, %v", multi[1].Cmd, multi[1].TTL)
 							}
 							return &valkeyresults{
-								s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
+								s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
 							}
 						},
 					}
@@ -2846,8 +2846,8 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					newResult(strmsg('+', "value1"), nil),
-					newResult(strmsg('+', "value2"), nil),
+					NewResult(strmsg('+', "value1"), nil),
+					NewResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -2941,10 +2941,10 @@ func TestSendToReplicasSentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -3128,7 +3128,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(strmsg('+', "Do"), nil)
+			return NewResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -3144,7 +3144,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(strmsg('+', "DoCache"), nil)
+			return NewResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -3178,7 +3178,7 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd[1])
 			}
 			return &valkeyresults{
-				s: []ValkeyResult{newResult(strmsg('+', "value1"), nil), newResult(strmsg('+', "value2"), nil)},
+				s: []ValkeyResult{NewResult(strmsg('+', "value1"), nil), NewResult(strmsg('+', "value2"), nil)},
 			}
 		}
 		resps := client.DoMulti(context.Background(), c1, c2)
@@ -3221,8 +3221,8 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 			}
 			return &valkeyresults{
 				s: []ValkeyResult{
-					newResult(strmsg('+', "value1"), nil),
-					newResult(strmsg('+', "value2"), nil),
+					NewResult(strmsg('+', "value1"), nil),
+					NewResult(strmsg('+', "value2"), nil),
 				},
 			}
 		}
@@ -3267,10 +3267,10 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -3319,10 +3319,10 @@ func TestReplicaOnlySentinelClientDelegate(t *testing.T) {
 
 		w := &mockWire{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "Delegate"), nil)
+				return NewResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *valkeyresults {
-				return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "Delegate"), nil)}}
+				return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -64,16 +64,16 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return "p"
 		},
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(errors.New("primary"))
+			return NewErrorResult(errors.New("primary"))
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("primary"))}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(errors.New("primary"))}}
 		},
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newErrResult(errors.New("primary"))
+			return NewErrorResult(errors.New("primary"))
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("primary"))}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(errors.New("primary"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
 			return ValkeyResultStream{e: errors.New("primary")}
@@ -93,10 +93,10 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return "r"
 		},
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(errors.New("replica"))
+			return NewErrorResult(errors.New("replica"))
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("replica"))}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(errors.New("replica"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
 			return ValkeyResultStream{e: errors.New("replica")}
@@ -220,7 +220,7 @@ func TestNewStandaloneClientMultiReplicasDelegation(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult {
 				i, _ := strconv.Atoi(dst)
 				atomic.AddInt32(&counts[i], 1)
-				return newErrResult(errors.New("replica"))
+				return NewErrorResult(errors.New("replica"))
 			},
 		}
 	}, newRetryer(defaultRetryDelayFn))
@@ -254,7 +254,7 @@ func TestStandaloneRedirectHandling(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrorResult(&redirectErr)
 		},
 	}
 
@@ -313,7 +313,7 @@ func TestStandaloneDoCacheRedirectHandling(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrorResult(&redirectErr)
 		},
 	}
 
@@ -372,7 +372,7 @@ func TestStandaloneRedirectDisabled(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrorResult(&redirectErr)
 		},
 	}
 
@@ -413,7 +413,7 @@ func TestStandaloneDoCacheRedirectDisabled(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrorResult(&redirectErr)
 		},
 	}
 
@@ -702,7 +702,7 @@ func TestStandaloneDoMultiWithRedirectRetry(t *testing.T) {
 			attempts++
 			// First attempt returns redirect error, second returns success
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(&redirectErr)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{ValkeyResult{val: strmsg('+', "OK")}}}
 		},
@@ -782,7 +782,7 @@ func TestStandaloneDoMultiWithRedirectRetryFailure(t *testing.T) {
 	primaryConn := &mockConn{
 		DialFn: func() error { return nil },
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(&redirectErr)}}
 		},
 	}
 
@@ -855,7 +855,7 @@ func TestStandaloneDoMultiCacheWithRedirectRetry(t *testing.T) {
 			attempts++
 			// First attempt returns redirect error, second returns success
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(&redirectErr)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{ValkeyResult{val: strmsg('+', "OK")}}}
 		},
@@ -935,7 +935,7 @@ func TestStandaloneDoMultiCacheWithRedirectRetryFailure(t *testing.T) {
 	primaryConn := &mockConn{
 		DialFn: func() error { return nil },
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrorResult(&redirectErr)}}
 		},
 	}
 
@@ -1104,7 +1104,7 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		primary.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrorResult(errConnExpired)
 			}
 			return newResult(strmsg('+', "OK"), nil)
 		}
@@ -1121,8 +1121,8 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			attempts++
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{
-					newErrResult(errConnExpired),
-					newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired),
+					NewErrorResult(errConnExpired),
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
@@ -1153,7 +1153,7 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{
 					newResult(strmsg('+', "OK"), nil),
-					newErrResult(errConnExpired),
+					NewErrorResult(errConnExpired),
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
@@ -1181,7 +1181,7 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		replica.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
@@ -1202,7 +1202,7 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		redirectConn.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -64,16 +64,16 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return "p"
 		},
 		DoFn: func(cmd Completed) ValkeyResult {
-			return NewErrResult(errors.New("primary"))
+			return newErrResult(errors.New("primary"))
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(errors.New("primary"))}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("primary"))}}
 		},
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return NewErrResult(errors.New("primary"))
+			return newErrResult(errors.New("primary"))
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(errors.New("primary"))}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("primary"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
 			return ValkeyResultStream{e: errors.New("primary")}
@@ -93,10 +93,10 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return "r"
 		},
 		DoFn: func(cmd Completed) ValkeyResult {
-			return NewErrResult(errors.New("replica"))
+			return newErrResult(errors.New("replica"))
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(errors.New("replica"))}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("replica"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
 			return ValkeyResultStream{e: errors.New("replica")}
@@ -220,7 +220,7 @@ func TestNewStandaloneClientMultiReplicasDelegation(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult {
 				i, _ := strconv.Atoi(dst)
 				atomic.AddInt32(&counts[i], 1)
-				return NewErrResult(errors.New("replica"))
+				return newErrResult(errors.New("replica"))
 			},
 		}
 	}, newRetryer(defaultRetryDelayFn))
@@ -254,7 +254,7 @@ func TestStandaloneRedirectHandling(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoFn: func(cmd Completed) ValkeyResult {
-			return NewErrResult(&redirectErr)
+			return newErrResult(&redirectErr)
 		},
 	}
 
@@ -313,7 +313,7 @@ func TestStandaloneDoCacheRedirectHandling(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return NewErrResult(&redirectErr)
+			return newErrResult(&redirectErr)
 		},
 	}
 
@@ -372,7 +372,7 @@ func TestStandaloneRedirectDisabled(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoFn: func(cmd Completed) ValkeyResult {
-			return NewErrResult(&redirectErr)
+			return newErrResult(&redirectErr)
 		},
 	}
 
@@ -413,7 +413,7 @@ func TestStandaloneDoCacheRedirectDisabled(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return NewErrResult(&redirectErr)
+			return newErrResult(&redirectErr)
 		},
 	}
 
@@ -702,7 +702,7 @@ func TestStandaloneDoMultiWithRedirectRetry(t *testing.T) {
 			attempts++
 			// First attempt returns redirect error, second returns success
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{ValkeyResult{val: strmsg('+', "OK")}}}
 		},
@@ -782,7 +782,7 @@ func TestStandaloneDoMultiWithRedirectRetryFailure(t *testing.T) {
 	primaryConn := &mockConn{
 		DialFn: func() error { return nil },
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
 		},
 	}
 
@@ -855,7 +855,7 @@ func TestStandaloneDoMultiCacheWithRedirectRetry(t *testing.T) {
 			attempts++
 			// First attempt returns redirect error, second returns success
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{ValkeyResult{val: strmsg('+', "OK")}}}
 		},
@@ -935,7 +935,7 @@ func TestStandaloneDoMultiCacheWithRedirectRetryFailure(t *testing.T) {
 	primaryConn := &mockConn{
 		DialFn: func() error { return nil },
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
+			return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
 		},
 	}
 
@@ -1002,7 +1002,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 	t.Run("ReadNodeSelector", func(t *testing.T) {
 		primaryNodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "primary"), nil)
+				return newResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1a"
@@ -1010,7 +1010,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 		}
 		replica1NodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "replica1"), nil)
+				return newResult(strmsg('+', "replica1"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1a" // Same AZ as client
@@ -1018,7 +1018,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 		}
 		replica2NodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return NewResult(strmsg('+', "replica2"), nil)
+				return newResult(strmsg('+', "replica2"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1b" // Different AZ
@@ -1104,9 +1104,9 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		primary.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return NewErrResult(errConnExpired)
+				return newErrResult(errConnExpired)
 			}
-			return NewResult(strmsg('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Set().Key("k").Value("v").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1121,13 +1121,13 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			attempts++
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{
-					NewErrResult(errConnExpired),
-					NewErrResult(errConnExpired),
+					newErrResult(errConnExpired),
+					newErrResult(errConnExpired),
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				NewResult(strmsg('+', "1"), nil),
-				NewResult(strmsg('+', "2"), nil),
+				newResult(strmsg('+', "1"), nil),
+				newResult(strmsg('+', "2"), nil),
 			}}
 		}
 		resps := client.DoMulti(context.Background(),
@@ -1152,12 +1152,12 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			attempts++
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{
-					NewResult(strmsg('+', "OK"), nil),
-					NewErrResult(errConnExpired),
+					newResult(strmsg('+', "OK"), nil),
+					newErrResult(errConnExpired),
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				NewResult(strmsg('+', "OK"), nil),
+				newResult(strmsg('+', "OK"), nil),
 			}}
 		}
 		resps := client.DoMulti(context.Background(),
@@ -1181,9 +1181,9 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		replica.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(),
 			client.B().Get().Key("k").Build(),
@@ -1202,9 +1202,9 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		redirectConn.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		client, err := newStandaloneClient(

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -76,7 +76,7 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return &valkeyresults{s: []ValkeyResult{NewErrorResult(errors.New("primary"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{e: errors.New("primary")}
+			return NewErrorResultStream(errors.New("primary"))
 		},
 		DoMultiStreamFn: func(cmd ...Completed) MultiValkeyResultStream {
 			return MultiValkeyResultStream{e: errors.New("primary")}
@@ -99,7 +99,7 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return &valkeyresults{s: []ValkeyResult{NewErrorResult(errors.New("replica"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{e: errors.New("replica")}
+			return NewErrorResultStream(errors.New("replica"))
 		},
 		DoMultiStreamFn: func(cmd ...Completed) MultiValkeyResultStream {
 			return MultiValkeyResultStream{e: errors.New("replica")}
@@ -483,7 +483,7 @@ func TestStandaloneDoStreamToReplica(t *testing.T) {
 	primaryConn := &mockConn{
 		DialFn: func() error { return nil },
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
-			return ValkeyResultStream{e: errors.New("primary")}
+			return NewErrorResultStream(errors.New("primary"))
 		},
 	}
 
@@ -491,7 +491,7 @@ func TestStandaloneDoStreamToReplica(t *testing.T) {
 		DialFn: func() error { return nil },
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
 			replicaUsed = true
-			return ValkeyResultStream{e: errors.New("replica")}
+			return NewErrorResultStream(errors.New("replica"))
 		},
 	}
 

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -64,16 +64,16 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return "p"
 		},
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(errors.New("primary"))
+			return NewErrResult(errors.New("primary"))
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("primary"))}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(errors.New("primary"))}}
 		},
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newErrResult(errors.New("primary"))
+			return NewErrResult(errors.New("primary"))
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("primary"))}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(errors.New("primary"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
 			return ValkeyResultStream{e: errors.New("primary")}
@@ -93,10 +93,10 @@ func TestNewStandaloneClientDelegation(t *testing.T) {
 			return "r"
 		},
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(errors.New("replica"))
+			return NewErrResult(errors.New("replica"))
 		},
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(errors.New("replica"))}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(errors.New("replica"))}}
 		},
 		DoStreamFn: func(cmd Completed) ValkeyResultStream {
 			return ValkeyResultStream{e: errors.New("replica")}
@@ -220,7 +220,7 @@ func TestNewStandaloneClientMultiReplicasDelegation(t *testing.T) {
 			DoFn: func(cmd Completed) ValkeyResult {
 				i, _ := strconv.Atoi(dst)
 				atomic.AddInt32(&counts[i], 1)
-				return newErrResult(errors.New("replica"))
+				return NewErrResult(errors.New("replica"))
 			},
 		}
 	}, newRetryer(defaultRetryDelayFn))
@@ -254,7 +254,7 @@ func TestStandaloneRedirectHandling(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrResult(&redirectErr)
 		},
 	}
 
@@ -313,7 +313,7 @@ func TestStandaloneDoCacheRedirectHandling(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrResult(&redirectErr)
 		},
 	}
 
@@ -372,7 +372,7 @@ func TestStandaloneRedirectDisabled(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoFn: func(cmd Completed) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrResult(&redirectErr)
 		},
 	}
 
@@ -413,7 +413,7 @@ func TestStandaloneDoCacheRedirectDisabled(t *testing.T) {
 	// Mock primary connection that returns redirect
 	primaryConn := &mockConn{
 		DoCacheFn: func(cmd Cacheable, ttl time.Duration) ValkeyResult {
-			return newErrResult(&redirectErr)
+			return NewErrResult(&redirectErr)
 		},
 	}
 
@@ -702,7 +702,7 @@ func TestStandaloneDoMultiWithRedirectRetry(t *testing.T) {
 			attempts++
 			// First attempt returns redirect error, second returns success
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{ValkeyResult{val: strmsg('+', "OK")}}}
 		},
@@ -782,7 +782,7 @@ func TestStandaloneDoMultiWithRedirectRetryFailure(t *testing.T) {
 	primaryConn := &mockConn{
 		DialFn: func() error { return nil },
 		DoMultiFn: func(multi ...Completed) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
 		},
 	}
 
@@ -855,7 +855,7 @@ func TestStandaloneDoMultiCacheWithRedirectRetry(t *testing.T) {
 			attempts++
 			// First attempt returns redirect error, second returns success
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
 			}
 			return &valkeyresults{s: []ValkeyResult{ValkeyResult{val: strmsg('+', "OK")}}}
 		},
@@ -935,7 +935,7 @@ func TestStandaloneDoMultiCacheWithRedirectRetryFailure(t *testing.T) {
 	primaryConn := &mockConn{
 		DialFn: func() error { return nil },
 		DoMultiCacheFn: func(multi ...CacheableTTL) *valkeyresults {
-			return &valkeyresults{s: []ValkeyResult{newErrResult(&redirectErr)}}
+			return &valkeyresults{s: []ValkeyResult{NewErrResult(&redirectErr)}}
 		},
 	}
 
@@ -1002,7 +1002,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 	t.Run("ReadNodeSelector", func(t *testing.T) {
 		primaryNodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "primary"), nil)
+				return NewResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1a"
@@ -1010,7 +1010,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 		}
 		replica1NodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica1"), nil)
+				return NewResult(strmsg('+', "replica1"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1a" // Same AZ as client
@@ -1018,7 +1018,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 		}
 		replica2NodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica2"), nil)
+				return NewResult(strmsg('+', "replica2"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1b" // Different AZ
@@ -1104,9 +1104,9 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		primary.DoFn = func(cmd Completed) ValkeyResult {
 			attempts++
 			if attempts == 1 {
-				return newErrResult(errConnExpired)
+				return NewErrResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Set().Key("k").Value("v").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1121,13 +1121,13 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			attempts++
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{
-					newErrResult(errConnExpired),
-					newErrResult(errConnExpired),
+					NewErrResult(errConnExpired),
+					NewErrResult(errConnExpired),
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				newResult(strmsg('+', "1"), nil),
-				newResult(strmsg('+', "2"), nil),
+				NewResult(strmsg('+', "1"), nil),
+				NewResult(strmsg('+', "2"), nil),
 			}}
 		}
 		resps := client.DoMulti(context.Background(),
@@ -1152,12 +1152,12 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			attempts++
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
-					newErrResult(errConnExpired),
+					NewResult(strmsg('+', "OK"), nil),
+					NewErrResult(errConnExpired),
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				newResult(strmsg('+', "OK"), nil),
+				NewResult(strmsg('+', "OK"), nil),
 			}}
 		}
 		resps := client.DoMulti(context.Background(),
@@ -1181,9 +1181,9 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		replica.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(),
 			client.B().Get().Key("k").Build(),
@@ -1202,9 +1202,9 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 		redirectConn.DoMultiFn = func(multi ...Completed) *valkeyresults {
 			attempts++
 			if attempts == 1 {
-				return &valkeyresults{s: []ValkeyResult{newErrResult(errConnExpired)}}
+				return &valkeyresults{s: []ValkeyResult{NewErrResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		client, err := newStandaloneClient(

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -1002,7 +1002,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 	t.Run("ReadNodeSelector", func(t *testing.T) {
 		primaryNodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "primary"), nil)
+				return NewResult(strmsg('+', "primary"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1a"
@@ -1010,7 +1010,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 		}
 		replica1NodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica1"), nil)
+				return NewResult(strmsg('+', "replica1"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1a" // Same AZ as client
@@ -1018,7 +1018,7 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 		}
 		replica2NodeConn := &mockConn{
 			DoFn: func(cmd Completed) ValkeyResult {
-				return newResult(strmsg('+', "replica2"), nil)
+				return NewResult(strmsg('+', "replica2"), nil)
 			},
 			AZFn: func() string {
 				return "us-east-1b" // Different AZ
@@ -1106,7 +1106,7 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			if attempts == 1 {
 				return NewErrorResult(errConnExpired)
 			}
-			return newResult(strmsg('+', "OK"), nil)
+			return NewResult(strmsg('+', "OK"), nil)
 		}
 		if v, err := client.Do(context.Background(), client.B().Set().Key("k").Value("v").Build()).ToString(); err != nil || v != "OK" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1126,8 +1126,8 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				newResult(strmsg('+', "1"), nil),
-				newResult(strmsg('+', "2"), nil),
+				NewResult(strmsg('+', "1"), nil),
+				NewResult(strmsg('+', "2"), nil),
 			}}
 		}
 		resps := client.DoMulti(context.Background(),
@@ -1152,12 +1152,12 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			attempts++
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{
-					newResult(strmsg('+', "OK"), nil),
+					NewResult(strmsg('+', "OK"), nil),
 					NewErrorResult(errConnExpired),
 				}}
 			}
 			return &valkeyresults{s: []ValkeyResult{
-				newResult(strmsg('+', "OK"), nil),
+				NewResult(strmsg('+', "OK"), nil),
 			}}
 		}
 		resps := client.DoMulti(context.Background(),
@@ -1183,7 +1183,7 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 		resps := client.DoMulti(context.Background(),
 			client.B().Get().Key("k").Build(),
@@ -1204,7 +1204,7 @@ func TestStandaloneClientConnLifetime(t *testing.T) {
 			if attempts == 1 {
 				return &valkeyresults{s: []ValkeyResult{NewErrorResult(errConnExpired)}}
 			}
-			return &valkeyresults{s: []ValkeyResult{newResult(strmsg('+', "OK"), nil)}}
+			return &valkeyresults{s: []ValkeyResult{NewResult(strmsg('+', "OK"), nil)}}
 		}
 
 		client, err := newStandaloneClient(

--- a/valkeycompat/pipeline.go
+++ b/valkeycompat/pipeline.go
@@ -77,7 +77,7 @@ type proxy struct {
 
 func (p *proxy) Do(_ context.Context, cmd valkey.Completed) valkey.ValkeyResult {
 	p.cmds = append(p.cmds, cmd)
-	return valkey.NewErrorResult(pipelineNotExeerrPipelineNotExecutedcutedErr)
+	return valkey.NewErrorResult(errPipelineNotExecuted)
 }
 
 func newPipeline(real valkey.Client) *Pipeline {

--- a/valkeycompat/pipeline.go
+++ b/valkeycompat/pipeline.go
@@ -31,7 +31,6 @@ import (
 	"errors"
 	"runtime"
 	"time"
-	"unsafe"
 
 	"github.com/valkey-io/valkey-go"
 )
@@ -69,12 +68,7 @@ type Pipeliner interface {
 var _ Pipeliner = (*Pipeline)(nil)
 var _ Cmdable = (*Pipeline)(nil)
 
-type proxyresult struct {
-	err error
-	val valkey.ValkeyMessage
-}
-
-var placeholder = proxyresult{err: errors.New("the pipeline has not been executed")}
+var errPipelineNotExecuted = errors.New("the pipeline has not been executed")
 
 type proxy struct {
 	valkey.Client
@@ -83,7 +77,7 @@ type proxy struct {
 
 func (p *proxy) Do(_ context.Context, cmd valkey.Completed) valkey.ValkeyResult {
 	p.cmds = append(p.cmds, cmd)
-	return *(*valkey.ValkeyResult)(unsafe.Pointer(&placeholder))
+	return valkey.NewErrorResult(pipelineNotExeerrPipelineNotExecutedcutedErr)
 }
 
 func newPipeline(real valkey.Client) *Pipeline {

--- a/valkeycompat/pipeline_test.go
+++ b/valkeycompat/pipeline_test.go
@@ -65,8 +65,8 @@ func testAdapterPipeline(resp3 bool) {
 		rets, err := adapter.Pipelined(ctx, func(pipe Pipeliner) error {
 			echo = pipe.Echo(ctx, "hello")
 			ping = pipe.Ping(ctx)
-			Expect(echo.Err()).To(MatchError(placeholder.err))
-			Expect(ping.Err()).To(MatchError(placeholder.err))
+			Expect(echo.Err()).To(MatchError(errPipelineNotExecuted))
+			Expect(ping.Err()).To(MatchError(errPipelineNotExecuted))
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -83,8 +83,8 @@ func testAdapterPipeline(resp3 bool) {
 		pipe := adapter.Pipeline()
 		echo := pipe.Echo(ctx, "hello")
 		ping := pipe.Ping(ctx)
-		Expect(echo.Err()).To(MatchError(placeholder.err))
-		Expect(ping.Err()).To(MatchError(placeholder.err))
+		Expect(echo.Err()).To(MatchError(errPipelineNotExecuted))
+		Expect(ping.Err()).To(MatchError(errPipelineNotExecuted))
 		Expect(pipe.Len()).To(Equal(2))
 
 		rets, err := pipe.Exec(ctx)
@@ -111,8 +111,8 @@ func testAdapterPipeline(resp3 bool) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rets).To(HaveLen(0))
 
-		Expect(echo.Err()).To(MatchError(placeholder.err))
-		Expect(ping.Err()).To(MatchError(placeholder.err))
+		Expect(echo.Err()).To(MatchError(errPipelineNotExecuted))
+		Expect(ping.Err()).To(MatchError(errPipelineNotExecuted))
 	})
 
 	if resp3 {
@@ -636,7 +636,7 @@ func TestPipeliner(t *testing.T) {
 			t.Fatalf("unexpected pipeline calls: %v", n)
 		}
 		for i, cmd := range p.rets {
-			if err := cmd.Err(); !errors.Is(err, placeholder.err) {
+			if err := cmd.Err(); !errors.Is(err, errPipelineNotExecuted) {
 				t.Fatalf("unexpected pipeline placeholder err(%d): %v", i, err)
 			}
 		}

--- a/valkeycompat/tx.go
+++ b/valkeycompat/tx.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"time"
-	"unsafe"
 
 	"github.com/valkey-io/valkey-go"
 )
@@ -47,11 +46,7 @@ func (c *TxPipeline) Exec(ctx context.Context) ([]Cmder, error) {
 	}
 	for i, r := range results {
 		rets[i].SetErr(nil)
-		rets[i].from(*(*valkey.ValkeyResult)(unsafe.Pointer(&proxyresult{
-			err: resp[i+1].NonValkeyError(),
-			val: r,
-		})))
-
+		rets[i].from(valkey.NewResult(r, resp[i+1].NonValkeyError()))
 		if err == nil {
 			err = rets[i].Err()
 		}

--- a/valkeycompat/tx_test.go
+++ b/valkeycompat/tx_test.go
@@ -60,8 +60,8 @@ func testAdapterTxPipeline(resp3 bool) {
 		rets, err := adapter.TxPipelined(ctx, func(pipe Pipeliner) error {
 			echo = pipe.Echo(ctx, "hello")
 			ping = pipe.Ping(ctx)
-			Expect(echo.Err()).To(MatchError(placeholder.err))
-			Expect(ping.Err()).To(MatchError(placeholder.err))
+			Expect(echo.Err()).To(MatchError(errPipelineNotExecuted))
+			Expect(ping.Err()).To(MatchError(errPipelineNotExecuted))
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -78,8 +78,8 @@ func testAdapterTxPipeline(resp3 bool) {
 		pipe := adapter.TxPipeline()
 		echo := pipe.Echo(ctx, "hello")
 		ping := pipe.Ping(ctx)
-		Expect(echo.Err()).To(MatchError(placeholder.err))
-		Expect(ping.Err()).To(MatchError(placeholder.err))
+		Expect(echo.Err()).To(MatchError(errPipelineNotExecuted))
+		Expect(ping.Err()).To(MatchError(errPipelineNotExecuted))
 		Expect(pipe.Len()).To(Equal(2))
 
 		rets, err := pipe.Exec(ctx)
@@ -106,8 +106,8 @@ func testAdapterTxPipeline(resp3 bool) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rets).To(HaveLen(0))
 
-		Expect(echo.Err()).To(MatchError(placeholder.err))
-		Expect(ping.Err()).To(MatchError(placeholder.err))
+		Expect(echo.Err()).To(MatchError(errPipelineNotExecuted))
+		Expect(ping.Err()).To(MatchError(errPipelineNotExecuted))
 	})
 
 	It("should Watch", func() {

--- a/valkeyhook/hook.go
+++ b/valkeyhook/hook.go
@@ -3,7 +3,6 @@ package valkeyhook
 import (
 	"context"
 	"time"
-	"unsafe"
 
 	"github.com/valkey-io/valkey-go"
 )
@@ -162,24 +161,10 @@ func (e *extended) Mode() valkey.ClientMode {
 	panic("Mode() is not allowed with valkey.DedicatedClient")
 }
 
-type result struct {
-	err error
-	val valkey.ValkeyMessage
-}
-
 func NewErrorResult(err error) valkey.ValkeyResult {
-	r := result{err: err}
-	return *(*valkey.ValkeyResult)(unsafe.Pointer(&r))
-}
-
-type stream struct {
-	p *int
-	w *int
-	e error
-	n int
+	return valkey.NewErrorResult(err)
 }
 
 func NewErrorResultStream(err error) valkey.ValkeyResultStream {
-	r := stream{e: err}
-	return *(*valkey.ValkeyResultStream)(unsafe.Pointer(&r))
+	return valkey.NewErrorResultStream(err)
 }


### PR DESCRIPTION
## Description

Addresses #146 

Valkey-go doesn't directly provide a way for consumers of the library to instantiate the ValkeyErrorResult directly, which results in submodules performing unsafe pointer conversions. The main concern is if modules get out of sync and types like ValkeyResult or ValkeyResultStream evolve, this could lead to memory corruption/app crashes.

This PR:

* Exposes the NewResult constructor for instantiating ValkeyResults with a ValkeyMessage and error
* Exposes the NewErrorResult constructor for instantiating ValkeyResults with an underlying error
* Exposes a new NewErrorResultStream method for instantiating ValkeyResultStreams with an underlying error, and updates existing tests that return just an error to use it.
* Updates valkeyhook to remove duplicated types with unsafe pointer conversions. 
* Updates valkeycompat to use NewResult and NewErrorResult.
* Removes mock's result type since it can just use the newly exposed constructors.

The diff here is pretty large, but the bulk of these are refactorings or struct initializations being swapped for new constructors.

## Design Questions:

* NewResult(msg, err) vs NewResult(msg) - I opted for the former since a lot of the submodules seem to do direct result{msg, err} type calls. That said, this does create some duplicated API Surface Area with NewErrorResult.
* Mark Methods as Deprecated - The valkeyhook.NewErrorResponse could be marked as deprecated, as can some of the mock methods. This feels like a maintainer preference question, so opted to leave them as is for now. 
