### PR TITLE
feat: add Close method to valkeylimiter

### DIFF
--- a/valkeylimiter/limiter.go
+++ b/valkeylimiter/limiter.go
@@ -28,6 +28,7 @@ type RateLimiterClient interface {
 	Allow(ctx context.Context, identifier string, options ...RateLimitOption) (Result, error)
 	AllowN(ctx context.Context, identifier string, n int64, options ...RateLimitOption) (Result, error)
 	Limit() int
+	Close()
 }
 
 const (
@@ -159,6 +160,10 @@ func (l *rateLimiter) AllowN(ctx context.Context, identifier string, n int64, op
 		Remaining: remaining,
 		ResetAtMs: resetAt,
 	}, nil
+}
+
+func (l *rateLimiter) Close() {
+	l.client.Close()
 }
 
 var rateLimitScript = valkey.NewLuaScript(`

--- a/valkeylimiter/limiter_test.go
+++ b/valkeylimiter/limiter_test.go
@@ -404,6 +404,27 @@ func TestRateLimiter_AllowN_Dragonfly(t *testing.T) {
 	}
 }
 
+func TestRateLimiter_Close(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Close().Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	limiter.Close()
+}
+
 func BenchmarkAllowN(b *testing.B) {
 	ctrl := gomock.NewController(b)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Description

This PR adds a simple Close method to valkeylimiter. 

When a limiter is created using ClientOptions, the package creates and owns an internal Valkey client. Previously, there was no public method to close this client, which could leave its connections and resources open for the lifetime of the application.

The new Close method allows callers to explicitly release these resources when the limiter is no longer needed.

Closes #148.

## Motivation

Applications should be able to properly clean up resources created internally by the package, especially in tests, short-lived processes, graceful shutdown flows, and applications that create multiple limiter instances.

## Changes
- Add a Close method to valkeylimiter.
- Close the internal Valkey client when it was created from ClientOptions.