### PR TITLE
GetToBuffer code latest changes

### DIFF
--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"encoding"
 	"fmt"
+	"io"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -115,6 +116,7 @@ type CoreCmdable interface {
 	Decr(ctx context.Context, key string) *IntCmd
 	DecrBy(ctx context.Context, key string, decrement int64) *IntCmd
 	Get(ctx context.Context, key string) *StringCmd
+	GetToBuffer(ctx context.Context, key string, buf []byte) *ZeroCopyStringCmd
 	GetRange(ctx context.Context, key string, start, end int64) *StringCmd
 	GetSet(ctx context.Context, key string, value any) *StringCmd
 	GetEx(ctx context.Context, key string, expiration time.Duration) *StringCmd
@@ -1002,6 +1004,51 @@ func (c *Compat) Get(ctx context.Context, key string) *StringCmd {
 	cmd := c.client.B().Get().Key(key).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newStringCmd(resp)
+}
+
+type bufferWriter struct {
+	buf []byte
+	pos int
+}
+
+func (w *bufferWriter) Write(p []byte) (int, error) {
+	remaining := len(w.buf) - w.pos
+
+	if remaining == 0 {
+		return 0, io.ErrShortBuffer
+	}
+
+	n := copy(w.buf[w.pos:], p)
+	w.pos += n
+
+	if n < len(p) {
+		return n, io.ErrShortBuffer
+	}
+
+	return n, nil
+}
+
+func (c *Compat) GetToBuffer(ctx context.Context, key string, buf []byte) *ZeroCopyStringCmd {
+	cmd := &ZeroCopyStringCmd{
+		baseCmd: baseCmd[int]{},
+		buf:     buf,
+	}
+
+	stream := c.client.DoStream(
+		ctx,
+		c.client.B().Get().Key(key).Build(),
+	)
+
+	writer := &bufferWriter{
+		buf: buf,
+	}
+
+	n, err := stream.WriteTo(writer)
+
+	cmd.SetVal(int(n))
+	cmd.SetErr(err)
+
+	return cmd
 }
 
 func (c *Compat) GetRange(ctx context.Context, key string, start, end int64) *StringCmd {

--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -1012,12 +1012,6 @@ type bufferWriter struct {
 }
 
 func (w *bufferWriter) Write(p []byte) (int, error) {
-	remaining := len(w.buf) - w.pos
-
-	if remaining == 0 {
-		return 0, io.ErrShortBuffer
-	}
-
 	n := copy(w.buf[w.pos:], p)
 	w.pos += n
 

--- a/valkeycompat/adapter_test.go
+++ b/valkeycompat/adapter_test.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -1472,6 +1473,120 @@ func testAdapter(resp3 bool) {
 			getRange = adapter.GetRange(ctx, "key", 10, 100)
 			Expect(getRange.Err()).NotTo(HaveOccurred())
 			Expect(getRange.Val()).To(Equal("string"))
+		})
+
+		It("should GetToBuffer", func() {
+			set := adapter.Set(ctx, "key", "hello", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+			Expect(set.Val()).To(Equal("OK"))
+
+			buf := make([]byte, 32)
+			get := adapter.GetToBuffer(ctx, "key", buf)
+
+			n, err := get.Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(5))
+			Expect(get.Val()).To(Equal(5))
+			Expect(get.Bytes()).To(Equal([]byte("hello")))
+		})
+
+		It("should GetToBuffer with exact size buffer", func() {
+			set := adapter.Set(ctx, "key", "hello", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+
+			buf := make([]byte, 5)
+			get := adapter.GetToBuffer(ctx, "key", buf)
+
+			n, err := get.Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(5))
+			Expect(get.Bytes()).To(Equal([]byte("hello")))
+		})
+
+		It("should GetToBuffer with larger buffer", func() {
+			set := adapter.Set(ctx, "key", "hello", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+
+			buf := make([]byte, 100)
+			get := adapter.GetToBuffer(ctx, "key", buf)
+
+			n, err := get.Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(5))
+			Expect(len(get.Bytes())).To(Equal(5))
+			Expect(get.Bytes()).To(Equal([]byte("hello")))
+		})
+
+		It("should GetToBuffer with small buffer and keep connection usable", func() {
+			set := adapter.Set(ctx, "large", "hello world", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+
+			set = adapter.Set(ctx, "next", "second", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+
+			buf := make([]byte, 5)
+			get := adapter.GetToBuffer(ctx, "large", buf)
+
+			n, err := get.Result()
+			Expect(n).To(Equal(5))
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(io.ErrShortBuffer))
+			Expect(get.Bytes()).To(Equal([]byte("hello")))
+
+			value, err := adapter.Get(ctx, "next").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("second"))
+		})
+
+		It("should GetToBuffer preserve missing key semantics", func() {
+			buf := make([]byte, 32)
+			get := adapter.GetToBuffer(ctx, "gtb-missing", buf)
+
+			n, err := get.Result()
+			Expect(n).To(Equal(0))
+			Expect(valkey.IsValkeyNil(err)).To(BeTrue())
+			Expect(get.Bytes()).To(BeEmpty())
+		})
+
+		It("should GetToBuffer handle empty value", func() {
+			set := adapter.Set(ctx, "gtb-empty", "", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+
+			buf := make([]byte, 32)
+			get := adapter.GetToBuffer(ctx, "gtb-empty", buf)
+
+			n, err := get.Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(0))
+			Expect(get.Bytes()).To(BeEmpty())
+		})
+
+		It("should GetToBuffer preserve binary payload", func() {
+			value := []byte{0x00, 0x01, 0xff, 0x7f, 0x80}
+			set := adapter.Set(ctx, "gtb-binary", string(value), 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+
+			buf := make([]byte, len(value))
+			get := adapter.GetToBuffer(ctx, "gtb-binary", buf)
+
+			n, err := get.Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(len(value)))
+			Expect(get.Bytes()).To(Equal(value))
+		})
+
+		It("should GetToBuffer handle large payload", func() {
+			value := strings.Repeat("x", 1024*1024)
+			set := adapter.Set(ctx, "gtb-large-payload", value, 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+
+			buf := make([]byte, len(value))
+			get := adapter.GetToBuffer(ctx, "gtb-large-payload", buf)
+
+			n, err := get.Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(len(value)))
+			Expect(get.Bytes()).To(Equal([]byte(value)))
 		})
 
 		It("should GetSet", func() {

--- a/valkeycompat/command.go
+++ b/valkeycompat/command.go
@@ -361,6 +361,25 @@ type StringCmd struct {
 	baseCmd[string]
 }
 
+type ZeroCopyStringCmd struct {
+	baseCmd[int]
+	buf []byte
+}
+
+func (cmd *ZeroCopyStringCmd) Bytes() []byte {
+	n := cmd.Val()
+
+	if n <= 0 {
+		return cmd.buf[:0]
+	}
+
+	if n > len(cmd.buf) {
+		n = len(cmd.buf)
+	}
+
+	return cmd.buf[:n]
+}
+
 func (cmd *StringCmd) from(res valkey.ValkeyResult) {
 	val, err := res.ToString()
 	cmd.SetErr(err)

--- a/valkeycompat/command.go
+++ b/valkeycompat/command.go
@@ -367,17 +367,7 @@ type ZeroCopyStringCmd struct {
 }
 
 func (cmd *ZeroCopyStringCmd) Bytes() []byte {
-	n := cmd.Val()
-
-	if n <= 0 {
-		return cmd.buf[:0]
-	}
-
-	if n > len(cmd.buf) {
-		n = len(cmd.buf)
-	}
-
-	return cmd.buf[:n]
+	return cmd.buf[:cmd.Val()]
 }
 
 func (cmd *StringCmd) from(res valkey.ValkeyResult) {

--- a/valkeycompat/pipeline.go
+++ b/valkeycompat/pipeline.go
@@ -368,6 +368,10 @@ func (c *Pipeline) Get(ctx context.Context, key string) *StringCmd {
 	return ret
 }
 
+func (c *Pipeline) GetToBuffer(ctx context.Context, key string, buf []byte) *ZeroCopyStringCmd {
+	panic("GetToBuffer is not supported in Pipeline")
+}
+
 func (c *Pipeline) GetRange(ctx context.Context, key string, start, end int64) *StringCmd {
 	ret := c.comp.GetRange(ctx, key, start, end)
 	c.rets = append(c.rets, ret)

--- a/valkeycompat/pipeline_test.go
+++ b/valkeycompat/pipeline_test.go
@@ -99,6 +99,14 @@ func testAdapterPipeline(resp3 bool) {
 		Expect(ping.Val()).To(Equal("PONG"))
 	})
 
+	It("should panic for GetToBuffer in Pipeline", func() {
+		pipe := adapter.Pipeline()
+
+		Expect(func() {
+			pipe.GetToBuffer(ctx, "key", make([]byte, 10))
+		}).To(Panic())
+	})
+
 	It("should Discard", func() {
 		pipe := adapter.Pipeline()
 		echo := pipe.Echo(ctx, "hello")

--- a/valkeycompat/tx.go
+++ b/valkeycompat/tx.go
@@ -147,3 +147,7 @@ func (t *tx) Close(_ context.Context) error {
 	t.cancel()
 	return nil
 }
+
+func (c *TxPipeline) GetToBuffer(ctx context.Context, key string, buf []byte) *ZeroCopyStringCmd {
+	panic("GetToBuffer is not supported in TxPipeline")
+}

--- a/valkeycompat/tx_test.go
+++ b/valkeycompat/tx_test.go
@@ -178,4 +178,12 @@ func testAdapterTxPipeline(resp3 bool) {
 			Expect(err).To(Equal(cmder.Err()))
 		})
 	}
+
+	It("should panic for GetToBuffer in TxPipeline", func() {
+		pipe := adapter.TxPipeline()
+
+		Expect(func() {
+			pipe.GetToBuffer(ctx, "key", make([]byte, 10))
+		}).To(Panic())
+	})
 }


### PR DESCRIPTION
**Summary**
This PR adds GetToBuffer support to the valkeycompat package to provide a go-redis-compatible API for reading a key directly into a caller-provided byte buffer.

The implementation uses the existing DoStream / WriteTo streaming path so the response is written directly into the provided buffer without first materializing the complete value.

**Changes**
Added GetToBuffer(ctx, key, buf) to CoreCmdable.

Added Compat.GetToBuffer using Client.DoStream().

Added ZeroCopyStringCmd to expose:

Added a bounded bufferWriter to write into the supplied buffer and return io.ErrShortBuffer when the buffer is insufficient.

Preserved the existing streaming behavior for draining oversized responses and keeping the connection reusable.

Added GetToBuffer methods to Pipeline and TxPipeline that panic because GetToBuffer requires a dedicated streaming connection and cannot be queued in a pipeline.

Added GetToBuffer coverage to the existing compatibility test suite.

**Test Coverage**

The tests cover:

Basic GET

Exact-size buffer

Larger buffer

Insufficient buffer / io.ErrShortBuffer

Connection reuse after a short-buffer response

Missing-key / Valkey Nil semantics

Empty values

Binary payloads

Large payloads

Pipeline / TxPipeline unsupported behavior

**Local Test Logs**

`Will run 20 of 887 specs

[BeforeSuite] 
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:77
[BeforeSuite] PASSED [0.015 seconds]

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

RESP3 Pipeline Commands should panic for GetToBuffer in Pipeline
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/pipeline_test.go:102
• [0.009 seconds]

SSSSS

RESP2 Pipeline Commands should panic for GetToBuffer in Pipeline
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/pipeline_test.go:102
• [0.005 seconds]

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

RESP2 Commands strings should GetToBuffer
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1478
• [0.019 seconds]

RESP2 Commands strings should GetToBuffer with exact size buffer
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1493
• [0.015 seconds]

RESP2 Commands strings should GetToBuffer with larger buffer
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1506
• [0.011 seconds]

RESP2 Commands strings should GetToBuffer with small buffer and keep connection usable
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1520
• [10.018 seconds]

RESP2 Commands strings should GetToBuffer preserve missing key semantics
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1541
• [0.014 seconds]

RESP2 Commands strings should GetToBuffer handle empty value
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1551
• [0.013 seconds]

RESP2 Commands strings should GetToBuffer preserve binary payload
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1564
• [0.016 seconds]

RESP2 Commands strings should GetToBuffer handle large payload
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1578
• [0.019 seconds]

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

RESP3 Commands strings should GetToBuffer
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1478
• [0.030 seconds]

RESP3 Commands strings should GetToBuffer with exact size buffer
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1493
• [0.027 seconds]

RESP3 Commands strings should GetToBuffer with larger buffer
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1506
• [0.029 seconds]

RESP3 Commands strings should GetToBuffer with small buffer and keep connection usable
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1520
• [10.030 seconds]

RESP3 Commands strings should GetToBuffer preserve missing key semantics
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1541
• [0.026 seconds]

RESP3 Commands strings should GetToBuffer handle empty value
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1551
• [0.025 seconds]

RESP3 Commands strings should GetToBuffer preserve binary payload
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1564
• [0.027 seconds]

RESP3 Commands strings should GetToBuffer handle large payload
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:1578
• [0.036 seconds]

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

RESP2 TxPipeline Commands should panic for GetToBuffer in TxPipeline
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/tx_test.go:182
• [0.005 seconds]

SSSSSSSSSSS

RESP3 TxPipeline Commands should panic for GetToBuffer in TxPipeline
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/tx_test.go:182
• [0.008 seconds]

[AfterSuite] 
/usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/adapter_test.go:121
[AfterSuite] PASSED [0.008 seconds]

Ran 20 of 887 Specs in 20.445 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 867 Skipped
--- PASS: TestAdapter (20.47s)
PASS
ok      github.com/valkey-io/valkey-go/valkeycompat     20.549s`

**Pipeline Test Output**

`=== RUN   TestPipeliner
=== RUN   TestPipeliner/Pipeline
=== RUN   TestPipeliner/Pipeline.Pipeline()
=== RUN   TestPipeliner/Pipeline.TxPipeline()
--- PASS: TestPipeliner (0.00s)
    --- PASS: TestPipeliner/Pipeline (0.00s)
    --- PASS: TestPipeliner/Pipeline.Pipeline() (0.00s)
    --- PASS: TestPipeliner/Pipeline.TxPipeline() (0.00s)
PASS
ok      github.com/valkey-io/valkey-go/valkeycompat     0.079s`

