### PR TITLE
feat: add RouteByLatency option for sentinel replica selection

### DIFF
--- a/route_by_latency_test.go
+++ b/route_by_latency_test.go
@@ -1,8 +1,10 @@
 package valkey
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -11,19 +13,22 @@ import (
 )
 
 func TestPickLowestLatencyReplica(t *testing.T) {
-	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	ctx := context.Background()
+
+	l1, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen l1: %v", err)
 	}
 	defer l1.Close()
 
-	l2, err := net.Listen("tcp", "127.0.0.1:0")
+	l2, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen l2: %v", err)
 	}
 	defer l2.Close()
 
-	l3, err := net.Listen("tcp", "127.0.0.1:0")
+	l3, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen l3: %v", err)
 	}
@@ -102,15 +107,18 @@ func TestPickLowestLatencyReplica(t *testing.T) {
 }
 
 func TestPickLowestLatencyReplica_FailbackToFasterNode(t *testing.T) {
+	var lc net.ListenConfig
+	ctx := context.Background()
+
 	// l1 is slow remote node (currently in use)
 	// l2 is fast local node that just recovered
-	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	l1, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen l1: %v", err)
 	}
 	defer l1.Close()
 
-	l2, err := net.Listen("tcp", "127.0.0.1:0")
+	l2, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen l2: %v", err)
 	}
@@ -186,11 +194,28 @@ func TestPickLowestLatencyReplica_FailbackToFasterNode(t *testing.T) {
 }
 
 func TestPickLowestLatencyReplica_WithUnreachableNodes(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	ctx := context.Background()
+
+	l, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}
 	defer l.Close()
+
+	unreach1, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen unreach1: %v", err)
+	}
+	unreachPort1 := strconv.Itoa(unreach1.Addr().(*net.TCPAddr).Port)
+	_ = unreach1.Close()
+
+	unreach2, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen unreach2: %v", err)
+	}
+	unreachPort2 := strconv.Itoa(unreach2.Addr().(*net.TCPAddr).Port)
+	_ = unreach2.Close()
 
 	go func() {
 		for {
@@ -208,9 +233,9 @@ func TestPickLowestLatencyReplica_WithUnreachableNodes(t *testing.T) {
 	validHost, validPort, _ := net.SplitHostPort(l.Addr().String())
 
 	eligible := []map[string]string{
-		{"ip": "127.0.0.1", "port": "59991"}, // unreachable
-		{"ip": validHost, "port": validPort},   // reachable
-		{"ip": "127.0.0.1", "port": "59992"}, // unreachable
+		{"ip": "127.0.0.1", "port": unreachPort1}, // unreachable
+		{"ip": validHost, "port": validPort},      // reachable
+		{"ip": "127.0.0.1", "port": unreachPort2}, // unreachable
 	}
 
 	client := &sentinelClient{
@@ -235,19 +260,70 @@ func TestPickLowestLatencyReplica_WithUnreachableNodes(t *testing.T) {
 
 func TestSentinelAutoEnableSendToReplicasAndRefreshInterval(t *testing.T) {
 	opt := &ClientOption{
-		InitAddress:    []string{"127.0.0.1:26379"},
+		InitAddress:    []string{"127.0.0.1:0"},
 		Sentinel:       SentinelOption{MasterSet: "mymaster"},
 		RouteByLatency: true,
 	}
 
-	if opt.RouteByLatency {
-		if opt.SendToReplicas == nil && !opt.ReplicaOnly {
-			opt.SendToReplicas = func(cmd Completed) bool { return cmd.IsReadOnly() }
-		}
-		if opt.Sentinel.TopologyRefreshInterval == 0 {
-			opt.Sentinel.TopologyRefreshInterval = 10 * time.Second
-		}
+	sentinelMock := &mockConn{
+		DoMultiFn: func(cmd ...Completed) *valkeyresults {
+			return &valkeyresults{
+				s: []ValkeyResult{
+					{
+						val: slicemsg('*', []ValkeyMessage{
+							slicemsg('%', []ValkeyMessage{
+								strmsg('+', "ip"), strmsg('+', "127.0.0.1"),
+								strmsg('+', "port"), strmsg('+', "0"),
+							}),
+						}),
+					},
+					{
+						val: slicemsg('*', []ValkeyMessage{
+							strmsg('+', "127.0.1.0"),
+							strmsg('+', "10"),
+						}),
+					},
+					{
+						val: slicemsg('*', []ValkeyMessage{
+							slicemsg('%', []ValkeyMessage{
+								strmsg('+', "ip"), strmsg('+', "127.0.1.1"),
+								strmsg('+', "port"), strmsg('+', "11"),
+							}),
+						}),
+					},
+				},
+			}
+		},
 	}
+
+	client, err := newSentinelClient(
+		opt,
+		func(dst string, opt *ClientOption) conn {
+			if dst == "127.0.0.1:0" {
+				return sentinelMock
+			}
+			if dst == "127.0.1.0:10" {
+				return &mockConn{
+					DoFn: func(cmd Completed) ValkeyResult {
+						return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "master")})}
+					},
+				}
+			}
+			if dst == "127.0.1.1:11" {
+				return &mockConn{
+					DoFn: func(cmd Completed) ValkeyResult {
+						return ValkeyResult{val: slicemsg('*', []ValkeyMessage{strmsg('+', "slave")})}
+					},
+				}
+			}
+			return &mockConn{}
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error creating sentinel client: %v", err)
+	}
+	defer client.Close()
 
 	if opt.SendToReplicas == nil {
 		t.Fatal("expected SendToReplicas to be auto-configured")

--- a/route_by_latency_test.go
+++ b/route_by_latency_test.go
@@ -1,0 +1,168 @@
+package valkey
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPickLowestLatencyReplica(t *testing.T) {
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen l1: %v", err)
+	}
+	defer l1.Close()
+
+	l2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen l2: %v", err)
+	}
+	defer l2.Close()
+
+	l3, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen l3: %v", err)
+	}
+	defer l3.Close()
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+
+	serveMock := func(l net.Listener, delay time.Duration) {
+		defer wg.Done()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				select {
+				case <-stopCh:
+					return
+				default:
+					return
+				}
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				var buf [32]byte
+				_, _ = c.Read(buf[:])
+				if delay > 0 {
+					time.Sleep(delay)
+				}
+				_, _ = c.Write([]byte("+PONG\r\n"))
+			}(conn)
+		}
+	}
+
+	wg.Add(3)
+	go serveMock(l1, 60*time.Millisecond)
+	go serveMock(l2, 0) // fast node (simulates local node)
+	go serveMock(l3, 30*time.Millisecond)
+
+	defer func() {
+		close(stopCh)
+		l1.Close()
+		l2.Close()
+		l3.Close()
+		wg.Wait()
+	}()
+
+	host1, port1, _ := net.SplitHostPort(l1.Addr().String())
+	host2, port2, _ := net.SplitHostPort(l2.Addr().String())
+	host3, port3, _ := net.SplitHostPort(l3.Addr().String())
+
+	eligible := []map[string]string{
+		{"ip": host1, "port": port1},
+		{"ip": host2, "port": port2},
+		{"ip": host3, "port": port3},
+	}
+
+	client := &sentinelClient{
+		mOpt: &ClientOption{
+			RouteByLatency: true,
+			Dialer: net.Dialer{
+				Timeout: 200 * time.Millisecond,
+			},
+		},
+	}
+
+	for i := 0; i < 5; i++ {
+		best, err := client.pickLowestLatencyReplica(eligible)
+		if err != nil {
+			t.Fatalf("iteration %d: pickLowestLatencyReplica failed: %v", i, err)
+		}
+
+		expectedAddr := fmt.Sprintf("%s:%s", host2, port2)
+		if best != expectedAddr {
+			t.Fatalf("iteration %d: expected lowest latency node %s, got %s", i, expectedAddr, best)
+		}
+	}
+}
+
+func TestPickLowestLatencyReplica_WithUnreachableNodes(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer l.Close()
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			var buf [32]byte
+			_, _ = conn.Read(buf[:])
+			_, _ = conn.Write([]byte("+PONG\r\n"))
+			_ = conn.Close()
+		}
+	}()
+
+	validHost, validPort, _ := net.SplitHostPort(l.Addr().String())
+
+	eligible := []map[string]string{
+		{"ip": "127.0.0.1", "port": "59991"}, // unreachable
+		{"ip": validHost, "port": validPort},   // reachable
+		{"ip": "127.0.0.1", "port": "59992"}, // unreachable
+	}
+
+	client := &sentinelClient{
+		mOpt: &ClientOption{
+			RouteByLatency: true,
+			Dialer: net.Dialer{
+				Timeout: 100 * time.Millisecond,
+			},
+		},
+	}
+
+	best, err := client.pickLowestLatencyReplica(eligible)
+	if err != nil {
+		t.Fatalf("pickLowestLatencyReplica failed with unreachable nodes: %v", err)
+	}
+
+	expected := fmt.Sprintf("%s:%s", validHost, validPort)
+	if best != expected {
+		t.Fatalf("expected reachable node %s, got %s", expected, best)
+	}
+}
+
+func TestSentinelAutoEnableSendToReplicas(t *testing.T) {
+	opt := &ClientOption{
+		InitAddress:    []string{"127.0.0.1:26379"},
+		Sentinel:       SentinelOption{MasterSet: "mymaster"},
+		RouteByLatency: true,
+	}
+
+	if opt.RouteByLatency && opt.SendToReplicas == nil && !opt.ReplicaOnly {
+		opt.SendToReplicas = func(cmd Completed) bool { return true }
+	}
+
+	if opt.SendToReplicas == nil {
+		t.Fatal("expected SendToReplicas to be auto-configured")
+	}
+
+	if !opt.SendToReplicas(Completed{}) {
+		t.Fatal("expected SendToReplicas to return true for commands")
+	}
+}

--- a/route_by_latency_test.go
+++ b/route_by_latency_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/valkey-io/valkey-go/internal/cmds"
 )
 
 func TestPickLowestLatencyReplica(t *testing.T) {
@@ -87,7 +89,7 @@ func TestPickLowestLatencyReplica(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		best, err := client.pickLowestLatencyReplica(eligible)
+		best, err := client.pickLowestLatencyReplica(eligible, "")
 		if err != nil {
 			t.Fatalf("iteration %d: pickLowestLatencyReplica failed: %v", i, err)
 		}
@@ -96,6 +98,90 @@ func TestPickLowestLatencyReplica(t *testing.T) {
 		if best != expectedAddr {
 			t.Fatalf("iteration %d: expected lowest latency node %s, got %s", i, expectedAddr, best)
 		}
+	}
+}
+
+func TestPickLowestLatencyReplica_FailbackToFasterNode(t *testing.T) {
+	// l1 is slow remote node (currently in use)
+	// l2 is fast local node that just recovered
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen l1: %v", err)
+	}
+	defer l1.Close()
+
+	l2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen l2: %v", err)
+	}
+	defer l2.Close()
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+
+	serveMock := func(l net.Listener, delay time.Duration) {
+		defer wg.Done()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				select {
+				case <-stopCh:
+					return
+				default:
+					return
+				}
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				var buf [32]byte
+				_, _ = c.Read(buf[:])
+				if delay > 0 {
+					time.Sleep(delay)
+				}
+				_, _ = c.Write([]byte("+PONG\r\n"))
+			}(conn)
+		}
+	}
+
+	wg.Add(2)
+	go serveMock(l1, 50*time.Millisecond) // currently in use, but slow
+	go serveMock(l2, 0)                   // recovered fast node
+
+	defer func() {
+		close(stopCh)
+		l1.Close()
+		l2.Close()
+		wg.Wait()
+	}()
+
+	host1, port1, _ := net.SplitHostPort(l1.Addr().String())
+	host2, port2, _ := net.SplitHostPort(l2.Addr().String())
+
+	eligible := []map[string]string{
+		{"ip": host1, "port": port1},
+		{"ip": host2, "port": port2},
+	}
+
+	client := &sentinelClient{
+		mOpt: &ClientOption{
+			RouteByLatency: true,
+			Dialer: net.Dialer{
+				Timeout: 200 * time.Millisecond,
+			},
+		},
+	}
+
+	currentSlowAddr := fmt.Sprintf("%s:%s", host1, port1)
+	expectedFastAddr := fmt.Sprintf("%s:%s", host2, port2)
+
+	// Even though current was set to slow node, client should failback to faster recovered node
+	best, err := client.pickLowestLatencyReplica(eligible, currentSlowAddr)
+	if err != nil {
+		t.Fatalf("pickLowestLatencyReplica failed: %v", err)
+	}
+
+	if best != expectedFastAddr {
+		t.Fatalf("expected failback to %s, got %s", expectedFastAddr, best)
 	}
 }
 
@@ -136,7 +222,7 @@ func TestPickLowestLatencyReplica_WithUnreachableNodes(t *testing.T) {
 		},
 	}
 
-	best, err := client.pickLowestLatencyReplica(eligible)
+	best, err := client.pickLowestLatencyReplica(eligible, "")
 	if err != nil {
 		t.Fatalf("pickLowestLatencyReplica failed with unreachable nodes: %v", err)
 	}
@@ -147,22 +233,40 @@ func TestPickLowestLatencyReplica_WithUnreachableNodes(t *testing.T) {
 	}
 }
 
-func TestSentinelAutoEnableSendToReplicas(t *testing.T) {
+func TestSentinelAutoEnableSendToReplicasAndRefreshInterval(t *testing.T) {
 	opt := &ClientOption{
 		InitAddress:    []string{"127.0.0.1:26379"},
 		Sentinel:       SentinelOption{MasterSet: "mymaster"},
 		RouteByLatency: true,
 	}
 
-	if opt.RouteByLatency && opt.SendToReplicas == nil && !opt.ReplicaOnly {
-		opt.SendToReplicas = func(cmd Completed) bool { return true }
+	if opt.RouteByLatency {
+		if opt.SendToReplicas == nil && !opt.ReplicaOnly {
+			opt.SendToReplicas = func(cmd Completed) bool { return cmd.IsReadOnly() }
+		}
+		if opt.Sentinel.TopologyRefreshInterval == 0 {
+			opt.Sentinel.TopologyRefreshInterval = 10 * time.Second
+		}
 	}
 
 	if opt.SendToReplicas == nil {
 		t.Fatal("expected SendToReplicas to be auto-configured")
 	}
 
-	if !opt.SendToReplicas(Completed{}) {
-		t.Fatal("expected SendToReplicas to return true for commands")
+	b := cmds.NewBuilder(cmds.NoSlot)
+	readCmd := b.Get().Key("key").Build()
+	writeCmd := b.Set().Key("key").Value("value").Build()
+
+	if !opt.SendToReplicas(readCmd) {
+		t.Fatal("expected SendToReplicas to return true for read commands")
+	}
+
+	if opt.SendToReplicas(writeCmd) {
+		t.Fatal("expected SendToReplicas to return false for write commands")
+	}
+
+	if opt.Sentinel.TopologyRefreshInterval != 10*time.Second {
+		t.Fatalf("expected TopologyRefreshInterval 10s, got %v", opt.Sentinel.TopologyRefreshInterval)
 	}
 }
+

--- a/sentinel.go
+++ b/sentinel.go
@@ -892,8 +892,11 @@ func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string, 
 	}
 
 	results := make(chan latencyResult, len(eligible))
-	dialer := c.mOpt.Dialer
-	timeout := dialer.Timeout
+	dialOpt := c.mOpt
+	if c.rOpt != nil {
+		dialOpt = c.rOpt
+	}
+	timeout := dialOpt.Dialer.Timeout
 	if timeout <= 0 {
 		timeout = 500 * time.Millisecond
 	}
@@ -905,7 +908,7 @@ func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string, 
 			defer cancel()
 
 			start := time.Now()
-			conn, err := dialer.DialContext(ctx, "tcp", targetAddr)
+			conn, err := dial(ctx, targetAddr, dialOpt)
 			if err != nil {
 				results <- latencyResult{addr: targetAddr, err: err}
 				return
@@ -914,9 +917,14 @@ func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string, 
 
 			_ = conn.SetDeadline(time.Now().Add(timeout))
 			// Send Valkey PING command to measure actual engine RTT
-			if _, err := conn.Write([]byte("*1\r\n$4\r\nPING\r\n")); err == nil {
-				var buf [7]byte
-				_, _ = conn.Read(buf[:])
+			if _, err := conn.Write([]byte("*1\r\n$4\r\nPING\r\n")); err != nil {
+				results <- latencyResult{addr: targetAddr, err: err}
+				return
+			}
+			var buf [7]byte
+			if _, err := io.ReadFull(conn, buf[:]); err != nil || string(buf[:]) != "+PONG\r\n" {
+				results <- latencyResult{addr: targetAddr, err: errors.New("invalid ping response")}
+				return
 			}
 
 			rtt := time.Since(start)

--- a/sentinel.go
+++ b/sentinel.go
@@ -42,6 +42,10 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		return nil, ErrInvalidTopologyRefreshInterval
 	}
 
+	if opt.RouteByLatency && opt.SendToReplicas == nil && !opt.ReplicaOnly {
+		opt.SendToReplicas = func(cmd Completed) bool { return true }
+	}
+
 	if opt.SendToReplicas != nil || opt.ReplicaOnly {
 		rOpt := *opt
 		rOpt.ReplicaOnly = true
@@ -802,7 +806,7 @@ func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sent
 
 	// we return a slave address instead of master
 	if c.replica {
-		addr, err := pickReplica(resp.s[1], c.currentReplica())
+		addr, err := c.pickReplica(resp.s[1], c.currentReplica())
 		if err != nil {
 			return "", "", nil, err
 		}
@@ -812,7 +816,7 @@ func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sent
 
 	var r string
 	if c.mOpt.SendToReplicas != nil {
-		addr, err := pickReplica(resp.s[2], c.currentReplica())
+		addr, err := c.pickReplica(resp.s[2], c.currentReplica())
 		if err != nil {
 			return "", "", nil, err
 		}
@@ -829,16 +833,8 @@ func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sent
 
 // pickReplica chooses which replica to talk to. current is the address already
 // in use, if any: it is kept whenever it is still eligible, and only a client
-// that has none, or whose replica has gone away, draws a new one at random.
-//
-// The random draw spreads clients over the replicas, but it belongs at the
-// point where a client needs a replica, not at every refresh. Refresh used to
-// happen only on a sentinel event, so re-drawing there was rare; with
-// TopologyRefreshInterval it happens on every tick, and _switchTarget closes
-// the connection it replaces immediately, so a fresh draw on each tick would
-// tear down a working replica connection — and the requests in flight on it —
-// several times a minute for no reason.
-func pickReplica(resp ValkeyResult, current string) (string, error) {
+// that has none, or whose replica has gone away, draws a new one (via latency check or at random).
+func (c *sentinelClient) pickReplica(resp ValkeyResult, current string) (string, error) {
 	replicas, err := resp.ToArray()
 	if err != nil {
 		return "", err
@@ -869,7 +865,79 @@ func pickReplica(resp ValkeyResult, current string) (string, error) {
 		}
 	}
 
+	if c.mOpt != nil && c.mOpt.RouteByLatency && len(eligible) > 1 {
+		return c.pickLowestLatencyReplica(eligible)
+	}
+
 	// choose a replica randomly
+	m := eligible[util.FastRand(len(eligible))]
+	return net.JoinHostPort(m["ip"], m["port"]), nil
+}
+
+func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string) (string, error) {
+	type latencyResult struct {
+		addr string
+		rtt  time.Duration
+		err  error
+	}
+
+	results := make(chan latencyResult, len(eligible))
+	dialer := c.mOpt.Dialer
+	timeout := dialer.Timeout
+	if timeout <= 0 {
+		timeout = 500 * time.Millisecond
+	}
+
+	for _, rep := range eligible {
+		addr := net.JoinHostPort(rep["ip"], rep["port"])
+		go func(targetAddr string) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			start := time.Now()
+			conn, err := dialer.DialContext(ctx, "tcp", targetAddr)
+			if err != nil {
+				results <- latencyResult{addr: targetAddr, err: err}
+				return
+			}
+			defer conn.Close()
+
+			_ = conn.SetDeadline(time.Now().Add(timeout))
+			// Send Valkey PING command to measure actual engine RTT
+			if _, err := conn.Write([]byte("*1\r\n$4\r\nPING\r\n")); err == nil {
+				var buf [7]byte
+				_, _ = conn.Read(buf[:])
+			}
+
+			rtt := time.Since(start)
+			results <- latencyResult{addr: targetAddr, rtt: rtt}
+		}(addr)
+	}
+
+	var bestAddr string
+	var minRTT time.Duration = time.Hour
+	var fallbackAddr string
+
+	for range eligible {
+		res := <-results
+		if res.err == nil {
+			if fallbackAddr == "" {
+				fallbackAddr = res.addr
+			}
+			if res.rtt < minRTT {
+				minRTT = res.rtt
+				bestAddr = res.addr
+			}
+		}
+	}
+
+	if bestAddr != "" {
+		return bestAddr, nil
+	}
+	if fallbackAddr != "" {
+		return fallbackAddr, nil
+	}
+
 	m := eligible[util.FastRand(len(eligible))]
 	return net.JoinHostPort(m["ip"], m["port"]), nil
 }

--- a/sentinel.go
+++ b/sentinel.go
@@ -42,8 +42,13 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		return nil, ErrInvalidTopologyRefreshInterval
 	}
 
-	if opt.RouteByLatency && opt.SendToReplicas == nil && !opt.ReplicaOnly {
-		opt.SendToReplicas = func(cmd Completed) bool { return true }
+	if opt.RouteByLatency {
+		if opt.SendToReplicas == nil && !opt.ReplicaOnly {
+			opt.SendToReplicas = func(cmd Completed) bool { return cmd.IsReadOnly() }
+		}
+		if opt.Sentinel.TopologyRefreshInterval == 0 {
+			opt.Sentinel.TopologyRefreshInterval = 10 * time.Second
+		}
 	}
 
 	if opt.SendToReplicas != nil || opt.ReplicaOnly {
@@ -832,8 +837,9 @@ func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sent
 }
 
 // pickReplica chooses which replica to talk to. current is the address already
-// in use, if any: it is kept whenever it is still eligible, and only a client
-// that has none, or whose replica has gone away, draws a new one (via latency check or at random).
+// in use, if any: it is kept whenever it is still eligible (unless RouteByLatency
+// discovers a significantly lower latency replica), and only a client that has none,
+// or whose replica has gone away, draws a new one (via latency check or at random).
 func (c *sentinelClient) pickReplica(resp ValkeyResult, current string) (string, error) {
 	replicas, err := resp.ToArray()
 	if err != nil {
@@ -856,6 +862,14 @@ func (c *sentinelClient) pickReplica(resp ValkeyResult, current string) (string,
 		return "", fmt.Errorf("not enough ready replicas")
 	}
 
+	if len(eligible) == 1 {
+		return net.JoinHostPort(eligible[0]["ip"], eligible[0]["port"]), nil
+	}
+
+	if c.mOpt != nil && c.mOpt.RouteByLatency {
+		return c.pickLowestLatencyReplica(eligible, current)
+	}
+
 	// stay on the replica already in use while it is still healthy
 	if current != "" {
 		for _, m := range eligible {
@@ -865,16 +879,12 @@ func (c *sentinelClient) pickReplica(resp ValkeyResult, current string) (string,
 		}
 	}
 
-	if c.mOpt != nil && c.mOpt.RouteByLatency && len(eligible) > 1 {
-		return c.pickLowestLatencyReplica(eligible)
-	}
-
 	// choose a replica randomly
 	m := eligible[util.FastRand(len(eligible))]
 	return net.JoinHostPort(m["ip"], m["port"]), nil
 }
 
-func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string) (string, error) {
+func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string, current string) (string, error) {
 	type latencyResult struct {
 		addr string
 		rtt  time.Duration
@@ -916,6 +926,8 @@ func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string) 
 
 	var bestAddr string
 	var minRTT time.Duration = time.Hour
+	var currentRTT time.Duration = time.Hour
+	var currentFound bool
 	var fallbackAddr string
 
 	for range eligible {
@@ -924,11 +936,21 @@ func (c *sentinelClient) pickLowestLatencyReplica(eligible []map[string]string) 
 			if fallbackAddr == "" {
 				fallbackAddr = res.addr
 			}
+			if res.addr == current {
+				currentFound = true
+				currentRTT = res.rtt
+			}
 			if res.rtt < minRTT {
 				minRTT = res.rtt
 				bestAddr = res.addr
 			}
 		}
+	}
+
+	// If current connection is still healthy and is either already the best
+	// or has negligible difference (within 200us), retain it to avoid unnecessary connection churn.
+	if currentFound && (current == bestAddr || currentRTT <= minRTT+200*time.Microsecond) {
+		return current, nil
 	}
 
 	if bestAddr != "" {

--- a/valkey.go
+++ b/valkey.go
@@ -269,6 +269,10 @@ type ClientOption struct {
 	//  if valkey instance is a cluster or a single valkey instance.
 	ForceSingleClient bool
 
+	// RouteByLatency when connecting to Sentinel with SendToReplicas (or ReplicaOnly),
+	// measures network/PING latency to all eligible replicas and selects the one with the lowest latency.
+	RouteByLatency bool
+
 	// ReplicaOnly indicates that this client will only try to connect to readonly replicas of valkey setup.
 	ReplicaOnly bool
 

--- a/valkey.go
+++ b/valkey.go
@@ -271,6 +271,9 @@ type ClientOption struct {
 
 	// RouteByLatency when connecting to Sentinel with SendToReplicas (or ReplicaOnly),
 	// measures network/PING latency to all eligible replicas and selects the one with the lowest latency.
+	// If SendToReplicas is nil and ReplicaOnly is false, the sentinel client sets SendToReplicas
+	// automatically so that read commands can reach replicas.
+	// This option has no effect on the cluster, standalone, or single clients.
 	RouteByLatency bool
 
 	// ReplicaOnly indicates that this client will only try to connect to readonly replicas of valkey setup.


### PR DESCRIPTION
### Summary

This PR adds the `RouteByLatency` option to `ClientOption` for Sentinel-managed clients, allowing read traffic to be routed to the replica with the lowest round-trip latency (e.g. co-located local nodes or same-rack/AZ replicas).

### Motivation

Currently, when `SendToReplicas` or `ReplicaOnly` is enabled in Sentinel mode, `valkey-go` selects an eligible replica uniformly at random (`util.FastRand`).

In many Kubernetes and multi-node deployments, Valkey replicas are deployed alongside application pods (e.g. as a DaemonSet or per-node instance). In such topologies:
- Reading from a co-located local replica on the same node achieves sub-millisecond latency (<0.1ms) with zero cross-node network overhead.
- Selecting a replica at random frequently routes requests across nodes or AZs, incurring unnecessary 1–2ms round-trip latency and network bandwidth.

Similar to `go-redis`'s `RouteByLatency`, this PR enables clients to automatically discover and prefer the lowest-latency replica while preserving full failover and failback capabilities.

---

### Key Changes

1. **`ClientOption.RouteByLatency`**:
   - Added a new boolean field `RouteByLatency` to `ClientOption`.
   - When set to `true`:
     - Automatically routes read commands to replicas (`SendToReplicas = func(cmd Completed) bool { return true }`) if not explicitly specified.
     - Defaults `Sentinel.TopologyRefreshInterval` to `10s` if unset, enabling seamless periodic reconciliation and failback.

2. **Concurrent Latency Probing (`pickLowestLatencyReplica`)**:
   - Probes all non-`sdown` replicas in parallel using lightweight goroutines.
   - Measures end-to-end RTT using `dialer.DialContext` followed by a RESP `PING` (`*1\r\n$4\r\nPING\r\n`) to verify both TCP reachability and engine responsiveness.
   - Respects `dialer.Timeout` (or a 500ms fallback) to prevent blocking on hung nodes.

3. **Connection Stability & Failback Support**:
   - **Anti-Churn / Hysteresis Threshold (200µs)**: If the client is already connected to a healthy replica and its latency is within 200µs of the fastest node, the existing connection is retained to prevent socket reconnection churn during periodic refresh ticks.
   - **Automatic Failback**: If the local replica temporarily goes down and later recovers, the periodic refresh reconciler detects the lower latency and seamlessly migrates back to the local replica via atomic connection swap (`_switchTarget`).

4. **Zero Hot-Path Overhead**:
   - Latency probing only runs during initial connection or topology reconciliation. Regular command execution (`Do`, `DoMulti`, `DoCache`) continues to use atomic connection loading with zero added allocations.

---

### Test Coverage

Added comprehensive unit tests in `route_by_latency_test.go`:
- `TestPickLowestLatencyReplica`: Verifies that the lowest-latency node is consistently chosen among replicas with simulated network delays (0ms vs 30ms vs 60ms).
- `TestPickLowestLatencyReplica_FailbackToFasterNode`: Verifies that a client connected to a remote replica automatically migrates back when a lower-latency node recovers.
- `TestPickLowestLatencyReplica_WithUnreachableNodes`: Verifies graceful fallback when some nodes are offline or unreachable.
- `TestSentinelAutoEnableSendToReplicasAndRefreshInterval`: Verifies proper default configuration when `RouteByLatency` is enabled.

```bash
$ go test -v -run 'TestPickLowestLatencyReplica|TestSentinelAutoEnableSendToReplicasAndRefreshInterval' .
=== RUN   TestPickLowestLatencyReplica
--- PASS: TestPickLowestLatencyReplica (0.31s)
=== RUN   TestPickLowestLatencyReplica_FailbackToFasterNode
--- PASS: TestPickLowestLatencyReplica_FailbackToFasterNode (0.05s)
=== RUN   TestPickLowestLatencyReplica_WithUnreachableNodes
--- PASS: TestPickLowestLatencyReplica_WithUnreachableNodes (0.00s)
=== RUN   TestSentinelAutoEnableSendToReplicasAndRefreshInterval
--- PASS: TestSentinelAutoEnableSendToReplicasAndRefreshInterval (0.00s)
PASS
ok      github.com/valkey-io/valkey-go  0.848s
