### PR TITLE
fix(cluster): close conns added to c.conns while _refresh is unlocked

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -360,16 +360,28 @@ func (c *clusterClient) _refresh() (err error) {
 			conns[addr] = fresh
 		}
 	}
-	if replaced != nil {
-		for i := range wslots {
-			if cc, ok := replaced[wslots[i]]; ok {
-				wslots[i] = cc
+	for _, g := range groups {
+		hit := false
+		for i := range g.nodes {
+			if _, ok := replaced[g.nodes[i].conn]; ok {
+				hit = true
+				break
 			}
 		}
-		for _, nodes := range rslots {
-			for i := range nodes {
-				if cc, ok := replaced[nodes[i].conn]; ok {
-					nodes[i].conn = cc
+		if !hit {
+			continue
+		}
+		for _, slot := range g.slots {
+			for i := slot[0]; i <= slot[1] && i >= 0 && i < 16384; i++ {
+				if cc, ok := replaced[wslots[i]]; ok {
+					wslots[i] = cc
+				}
+				if rslots != nil {
+					for j := range rslots[i] {
+						if cc, ok := replaced[rslots[i][j].conn]; ok {
+							rslots[i][j].conn = cc
+						}
+					}
 				}
 			}
 		}

--- a/cluster.go
+++ b/cluster.go
@@ -360,26 +360,28 @@ func (c *clusterClient) _refresh() (err error) {
 			conns[addr] = fresh
 		}
 	}
-	for _, g := range groups {
-		hit := false
-		for i := range g.nodes {
-			if _, ok := replaced[g.nodes[i].conn]; ok {
-				hit = true
-				break
-			}
-		}
-		if !hit {
-			continue
-		}
-		for _, slot := range g.slots {
-			for i := slot[0]; i <= slot[1] && i >= 0 && i < 16384; i++ {
-				if cc, ok := replaced[wslots[i]]; ok {
-					wslots[i] = cc
+	if replaced != nil {
+		for _, g := range groups {
+			hit := false
+			for i := range g.nodes {
+				if _, ok := replaced[g.nodes[i].conn]; ok {
+					hit = true
+					break
 				}
-				if rslots != nil {
-					for j := range rslots[i] {
-						if cc, ok := replaced[rslots[i][j].conn]; ok {
-							rslots[i][j].conn = cc
+			}
+			if !hit {
+				continue
+			}
+			for _, slot := range g.slots {
+				for i := slot[0]; i <= slot[1] && i >= 0 && i < 16384; i++ {
+					if cc, ok := replaced[wslots[i]]; ok {
+						wslots[i] = cc
+					}
+					if rslots != nil {
+						for j := range rslots[i] {
+							if cc, ok := replaced[rslots[i][j].conn]; ok {
+								rslots[i][j].conn = cc
+							}
 						}
 					}
 				}

--- a/cluster.go
+++ b/cluster.go
@@ -257,15 +257,11 @@ func (c *clusterClient) _refresh() (err error) {
 		}
 	}
 
-	var removes []conn
-
 	c.mu.RLock()
 	for addr, cc := range c.conns {
 		if fresh, ok := conns[addr]; ok {
 			fresh.conn = cc.conn
 			conns[addr] = fresh
-		} else {
-			removes = append(removes, cc.conn)
 		}
 	}
 	c.mu.RUnlock()
@@ -340,7 +336,16 @@ func (c *clusterClient) _refresh() (err error) {
 		}
 	}
 
+	var removes []conn
+
 	c.mu.Lock()
+	// redirectOrNew may have changed c.conns while the lock was released above,
+	// so collect the removals here. Otherwise those conns are dropped without being closed.
+	for addr, cc := range c.conns {
+		if fresh, ok := conns[addr]; !ok || fresh.conn != cc.conn {
+			removes = append(removes, cc.conn)
+		}
+	}
 	c.wslots = wslots
 	c.rslots = rslots
 	c.conns = conns

--- a/cluster.go
+++ b/cluster.go
@@ -337,13 +337,40 @@ func (c *clusterClient) _refresh() (err error) {
 	}
 
 	var removes []conn
+	var replaced map[conn]conn
 
 	c.mu.Lock()
-	// redirectOrNew may have changed c.conns while the lock was released above,
-	// so collect the removals here. Otherwise those conns are dropped without being closed.
+	// redirectOrNew may have changed c.conns while the lock was released above.
+	// Reconcile here, otherwise the conns it added are dropped without being closed.
 	for addr, cc := range c.conns {
-		if fresh, ok := conns[addr]; !ok || fresh.conn != cc.conn {
+		fresh, ok := conns[addr]
+		if !ok {
 			removes = append(removes, cc.conn)
+			continue
+		}
+		if fresh.conn != cc.conn {
+			// redirectOrNew replaced the conn at this addr and already scheduled the
+			// one it replaced for closing, so keep the replacement and retarget the slots.
+			if replaced == nil {
+				replaced = make(map[conn]conn, 1)
+			}
+			replaced[fresh.conn] = cc.conn
+			fresh.conn = cc.conn
+			conns[addr] = fresh
+		}
+	}
+	if replaced != nil {
+		for i := range wslots {
+			if cc, ok := replaced[wslots[i]]; ok {
+				wslots[i] = cc
+			}
+		}
+		for _, nodes := range rslots {
+			for i := range nodes {
+				if cc, ok := replaced[nodes[i].conn]; ok {
+					nodes[i].conn = cc
+				}
+			}
 		}
 	}
 	c.wslots = wslots

--- a/cluster.go
+++ b/cluster.go
@@ -349,12 +349,13 @@ func (c *clusterClient) _refresh() (err error) {
 			continue
 		}
 		if fresh.conn != cc.conn {
-			// redirectOrNew replaced the conn at this addr and already scheduled the
-			// one it replaced for closing, so keep the replacement and retarget the slots.
+			// Keep the conn redirectOrNew installed here, and close fresh.conn since
+			// the AZ() calls above may have already connected it.
 			if replaced == nil {
 				replaced = make(map[conn]conn, 1)
 			}
 			replaced[fresh.conn] = cc.conn
+			removes = append(removes, fresh.conn)
 			fresh.conn = cc.conn
 			conns[addr] = fresh
 		}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -11539,3 +11539,117 @@ func TestClusterClientRefreshKeepsConnReplacedWhileUnlocked(t *testing.T) {
 		t.Fatal("wslots should point at the replacement conn")
 	}
 }
+
+var slotsRespWithExtraReplica = NewResult(slicemsg('*', []ValkeyMessage{
+	slicemsg('*', []ValkeyMessage{
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 16383},
+		slicemsg('*', []ValkeyMessage{ // master
+			strmsg('+', "127.0.0.1"),
+			{typ: ':', intlen: 0},
+			strmsg('+', ""),
+		}),
+		slicemsg('*', []ValkeyMessage{ // replica
+			strmsg('+', "127.0.1.1"),
+			{typ: ':', intlen: 1},
+			strmsg('+', ""),
+		}),
+		slicemsg('*', []ValkeyMessage{ // replica that only appears on the second refresh
+			strmsg('+', "127.0.0.2"),
+			{typ: ':', intlen: 2},
+			strmsg('+', ""),
+		}),
+	}),
+}), nil)
+
+func TestClusterClientRefreshClosesConnConnectedByAZ(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+
+	// For a node that only appears in the refreshed topology, _refresh carries a conn of
+	// its own and AZ() connects it. If redirectOrNew installs another conn at that addr
+	// while the lock is released, the connected one has to be closed, not just dropped.
+	const added = "127.0.0.2:2"
+
+	var clientp atomic.Pointer[clusterClient]
+	var once sync.Once
+	var extra atomic.Bool
+
+	var mu sync.Mutex
+	var madeForAdded []conn
+	closed := make(map[conn]bool)
+
+	client, err := newClusterClient(
+		&ClientOption{
+			InitAddress:         []string{"127.0.0.1:0"},
+			SendToReplicas:      func(cmd Completed) bool { return false },
+			EnableReplicaAZInfo: true,
+		},
+		func(dst string, opt *ClientOption) conn {
+			m := &mockConn{AddrFn: func() string { return dst }}
+			m.DoFn = func(cmd Completed) ValkeyResult {
+				if extra.Load() {
+					return slotsRespWithExtraReplica
+				}
+				return slotsResp
+			}
+			m.AZFn = func() string {
+				if dst == added {
+					if c := clientp.Load(); c != nil {
+						once.Do(func() { c.redirectOrNew(added, nil, 0, RedirectMove) })
+					}
+				}
+				return "us-west-1a"
+			}
+			m.CloseFn = func() {
+				mu.Lock()
+				closed[conn(m)] = true
+				mu.Unlock()
+			}
+			if dst == added {
+				mu.Lock()
+				madeForAdded = append(madeForAdded, conn(m))
+				mu.Unlock()
+			}
+			return m
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	defer client.Close()
+
+	clientp.Store(client)
+	extra.Store(true)
+
+	if err := client.refresh(context.Background()); err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	mu.Lock()
+	made := append([]conn(nil), madeForAdded...)
+	mu.Unlock()
+	if len(made) < 2 {
+		t.Fatalf("expected _refresh and redirectOrNew to make a conn each for %s, got %d", added, len(made))
+	}
+
+	client.mu.RLock()
+	got := client.conns[added].conn
+	client.mu.RUnlock()
+	if got != made[len(made)-1] {
+		t.Fatalf("conns[%s] should hold the conn redirectOrNew installed", added)
+	}
+
+	// removes are closed after a 5s delay
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := closed[made[0]]
+		mu.Unlock()
+		if done {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("the conn AZ() connected was dropped without being closed")
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -11410,3 +11410,69 @@ func clusterClientWithConnCount(n int) *clusterClient {
 	}
 	return &clusterClient{conns: conns}
 }
+
+func TestClusterClientRefreshClosesConnAddedWhileUnlocked(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+
+	// A MOVED redirection can insert a conn into c.conns while _refresh has
+	// released the read lock. _refresh must close it instead of just dropping it.
+	const redirected = "127.0.0.9:9"
+
+	var clientp atomic.Pointer[clusterClient]
+	var once sync.Once
+	closedCh := make(chan string, 8)
+
+	client, err := newClusterClient(
+		&ClientOption{
+			InitAddress:         []string{"127.0.0.1:0"},
+			SendToReplicas:      func(cmd Completed) bool { return false },
+			EnableReplicaAZInfo: true,
+		},
+		func(dst string, opt *ClientOption) conn {
+			return &mockConn{
+				DoFn:   func(cmd Completed) ValkeyResult { return slotsResp },
+				AddrFn: func() string { return dst },
+				AZFn: func() string {
+					// AZ() is called after _refresh released the read lock and
+					// before it takes the write lock, so redirect here.
+					if c := clientp.Load(); c != nil {
+						once.Do(func() { c.redirectOrNew(redirected, nil, 0, RedirectMove) })
+					}
+					return "us-west-1a"
+				},
+				CloseFn: func() { closedCh <- dst },
+			}
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	defer client.Close()
+
+	clientp.Store(client)
+
+	if err := client.refresh(context.Background()); err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	client.mu.RLock()
+	_, ok := client.conns[redirected]
+	client.mu.RUnlock()
+	if ok {
+		t.Fatalf("%s should have been dropped from conns", redirected)
+	}
+
+	// removes are closed after a 5s delay
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case dst := <-closedCh:
+			if dst == redirected {
+				return
+			}
+		case <-timeout:
+			t.Fatalf("%s was dropped from conns without being closed", redirected)
+		}
+	}
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -11476,3 +11476,66 @@ func TestClusterClientRefreshClosesConnAddedWhileUnlocked(t *testing.T) {
 		}
 	}
 }
+
+func TestClusterClientRefreshKeepsConnReplacedWhileUnlocked(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+
+	// redirectOrNew can also replace the conn at an unchanged addr while _refresh
+	// has released the read lock. It schedules the conn it replaced for closing,
+	// so the replacement has to survive the refresh.
+	const master = "127.0.0.1:0"
+
+	var clientp atomic.Pointer[clusterClient]
+	var replacement atomic.Value
+	var once sync.Once
+
+	client, err := newClusterClient(
+		&ClientOption{
+			InitAddress:         []string{master},
+			SendToReplicas:      func(cmd Completed) bool { return false },
+			EnableReplicaAZInfo: true,
+		},
+		func(dst string, opt *ClientOption) conn {
+			return &mockConn{
+				DoFn:   func(cmd Completed) ValkeyResult { return slotsResp },
+				AddrFn: func() string { return dst },
+				AZFn: func() string {
+					if c := clientp.Load(); c != nil {
+						once.Do(func() {
+							replacement.Store(c.redirectOrNew(master, c._pick(0, false), 0, RedirectMove))
+						})
+					}
+					return "us-west-1a"
+				},
+			}
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	defer client.Close()
+
+	clientp.Store(client)
+
+	if err := client.refresh(context.Background()); err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	want, _ := replacement.Load().(conn)
+	if want == nil {
+		t.Fatal("redirectOrNew was not called")
+	}
+
+	client.mu.RLock()
+	got := client.conns[master].conn
+	slot := client.wslots[0]
+	client.mu.RUnlock()
+
+	if got != want {
+		t.Fatalf("conns[%s] should hold the replacement conn", master)
+	}
+	if slot != want {
+		t.Fatal("wslots should point at the replacement conn")
+	}
+}


### PR DESCRIPTION
## Problem

`_refresh` reads `c.conns` under `RLock` and builds `removes` there, releases the lock, computes `wslots`, and only then overwrites `c.conns` under `Lock`. A conn that `redirectOrNew` inserts into `c.conns` during that window is dropped by the overwrite without being closed, so its connection stays established for the lifetime of the process.

Fixes #160

## Fix

Build the removal set under the write lock, comparing against the `conns` map that is about to be installed. An entry is closed when it is absent from that map, or when its conn differs from the one being installed.

The second condition also covers the `prev == cc.conn` branch of `redirectOrNew`, where the addr is unchanged but the conn was replaced: previously the overwrite reinstated the old conn and dropped the replacement without closing it.

## Tests

`TestClusterClientRefreshClosesConnAddedWhileUnlocked` reproduces the window deterministically, with no timing dependence. With `EnableReplicaAZInfo` set, `_refresh` calls `conn.AZ()` after releasing the read lock and before taking the write lock, so the mock's `AZFn` invokes `redirectOrNew` at exactly that point.

The test fails before this change (the conn is dropped from `c.conns` and never closed) and passes after it. `go test -race` on the cluster tests reports no data race.
