### PR TITLE
feat(valkeycompat): add SetFromBuffer for go-redis parity

### DIFF
--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -127,6 +127,8 @@ type CoreCmdable interface {
 	MSetNX(ctx context.Context, values ...any) *BoolCmd
 	Set(ctx context.Context, key string, value any, expiration time.Duration) *StatusCmd
 	SetArgs(ctx context.Context, key string, value any, a SetArgs) *StatusCmd
+	// SetFromBuffer sets the value of a key using a []byte buffer.
+	SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd
 	SetEX(ctx context.Context, key string, value any, expiration time.Duration) *StatusCmd
 	SetNX(ctx context.Context, key string, value any, expiration time.Duration) *BoolCmd
 	SetXX(ctx context.Context, key string, value any, expiration time.Duration) *BoolCmd
@@ -1163,6 +1165,15 @@ func (c *Compat) SetNX(ctx context.Context, key string, value any, expiration ti
 	}
 
 	return newBoolCmd(resp)
+}
+
+// SetFromBuffer sets the value of a key using the provided byte buffer.
+// This uses valkey.BinaryString to avoid an extra allocation when possible.
+func (c *Compat) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
+	value := valkey.BinaryString(buf)
+	cmd := c.client.B().Set().Key(key).Value(value).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newStatusCmd(resp)
 }
 
 func (c *Compat) SetXX(ctx context.Context, key string, value any, expiration time.Duration) *BoolCmd {

--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -129,6 +129,8 @@ type CoreCmdable interface {
 	MSetNX(ctx context.Context, values ...any) *BoolCmd
 	Set(ctx context.Context, key string, value any, expiration time.Duration) *StatusCmd
 	SetArgs(ctx context.Context, key string, value any, a SetArgs) *StatusCmd
+	// SetFromBuffer sets the value of a key using a []byte buffer.
+	SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd
 	SetEX(ctx context.Context, key string, value any, expiration time.Duration) *StatusCmd
 	SetNX(ctx context.Context, key string, value any, expiration time.Duration) *BoolCmd
 	SetXX(ctx context.Context, key string, value any, expiration time.Duration) *BoolCmd
@@ -1205,6 +1207,15 @@ func (c *Compat) SetNX(ctx context.Context, key string, value any, expiration ti
 	}
 
 	return newBoolCmd(resp)
+}
+
+// SetFromBuffer sets the value of a key using the provided byte buffer.
+// This uses valkey.BinaryString to avoid an extra allocation when possible.
+func (c *Compat) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
+	value := valkey.BinaryString(buf)
+	cmd := c.client.B().Set().Key(key).Value(value).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newStatusCmd(resp)
 }
 
 func (c *Compat) SetXX(ctx context.Context, key string, value any, expiration time.Duration) *BoolCmd {

--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -129,7 +129,6 @@ type CoreCmdable interface {
 	MSetNX(ctx context.Context, values ...any) *BoolCmd
 	Set(ctx context.Context, key string, value any, expiration time.Duration) *StatusCmd
 	SetArgs(ctx context.Context, key string, value any, a SetArgs) *StatusCmd
-	// SetFromBuffer sets the value of a key using a []byte buffer.
 	SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd
 	SetEX(ctx context.Context, key string, value any, expiration time.Duration) *StatusCmd
 	SetNX(ctx context.Context, key string, value any, expiration time.Duration) *BoolCmd
@@ -1209,8 +1208,6 @@ func (c *Compat) SetNX(ctx context.Context, key string, value any, expiration ti
 	return newBoolCmd(resp)
 }
 
-// SetFromBuffer sets the value of a key using the provided byte buffer.
-// This uses valkey.BinaryString to avoid an extra allocation when possible.
 func (c *Compat) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
 	value := valkey.BinaryString(buf)
 	cmd := c.client.B().Set().Key(key).Value(value).Build()

--- a/valkeycompat/adapter_test.go
+++ b/valkeycompat/adapter_test.go
@@ -27,14 +27,21 @@
 package valkeycompat
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"math"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"errors"
+
+	"github.com/valkey-io/valkey-go/mock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,6 +61,236 @@ func (t *TimeValue) ScanValkey(s string) (err error) {
 func TestAdapter(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Adapter Suite")
+}
+
+func TestSetFromBuffer_Adapter(t *testing.T) {
+	// helper that asserts the exact SET command shape
+	assertSetFromBufferCmd := func(t *testing.T, cmds []string, key string, payload []byte) {
+		t.Helper()
+		exp := valkey.BinaryString(payload)
+		if len(cmds) < 3 {
+			t.Fatalf("SET needs 3 args, got %v", cmds)
+		}
+		if cmds[0] != "SET" || cmds[1] != key || cmds[2] != exp {
+			t.Fatalf("want SET %q %q, got %v", key, exp, cmds)
+		}
+	}
+	t.Run("binary payload round-trip", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		client := mock.NewClient(ctrl)
+		adapter := NewAdapter(client)
+
+		key := "sfb-basic"
+		payload := []byte{0x00, 0x01, 0xff}
+
+		// capture the Completed command and assert exact shape
+		client.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, c valkey.Completed) valkey.ValkeyResult {
+			cmds := c.Commands()
+			assertSetFromBufferCmd(t, cmds, key, payload)
+			return mock.Result(mock.ValkeyString("OK"))
+		})
+		cmd := adapter.SetFromBuffer(context.Background(), key, payload)
+		ok, err := cmd.Result()
+		if err != nil {
+			t.Fatalf("Result err: %v", err)
+		}
+		if ok != "OK" {
+			t.Fatalf("Result() = %q, want OK", ok)
+		}
+	})
+
+	t.Run("empty buffer", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		client := mock.NewClient(ctrl)
+		adapter := NewAdapter(client)
+
+		key := "sfb-empty"
+		payload := []byte{}
+
+		client.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, c valkey.Completed) valkey.ValkeyResult {
+			cmds := c.Commands()
+			assertSetFromBufferCmd(t, cmds, key, payload)
+			return mock.Result(mock.ValkeyString("OK"))
+		})
+		cmd := adapter.SetFromBuffer(context.Background(), key, payload)
+		ok, err := cmd.Result()
+		if err != nil {
+			t.Fatalf("Result err: %v", err)
+		}
+		if ok != "OK" {
+			t.Fatalf("Result() = %q, want OK", ok)
+		}
+	})
+
+	t.Run("large payload", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		client := mock.NewClient(ctrl)
+		adapter := NewAdapter(client)
+
+		key := "sfb-large"
+		payload := []byte(strings.Repeat("x", 1<<20))
+
+		client.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, c valkey.Completed) valkey.ValkeyResult {
+			cmds := c.Commands()
+			assertSetFromBufferCmd(t, cmds, key, payload)
+			return mock.Result(mock.ValkeyString("OK"))
+		})
+		cmd := adapter.SetFromBuffer(context.Background(), key, payload)
+		ok, err := cmd.Result()
+		if err != nil {
+			t.Fatalf("Result err: %v", err)
+		}
+		if ok != "OK" {
+			t.Fatalf("Result() = %q, want OK", ok)
+		}
+	})
+
+	t.Run("context cancellation propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		client := mock.NewClient(ctrl)
+		adapter := NewAdapter(client)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		client.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(got context.Context, _ valkey.Completed) valkey.ValkeyResult {
+			if got.Err() != context.Canceled {
+				t.Errorf("Do ctx.Err() = %v, want Canceled", got.Err())
+			}
+			return mock.ErrorResult(context.Canceled)
+		})
+		err := adapter.SetFromBuffer(ctx, "test-cancel", []byte("payload")).Err()
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("pipeline panic", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		client := mock.NewClient(ctrl)
+		// create a pipeline wrapper that uses our adapter
+		p := NewAdapter(client).Pipeline()
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("expected panic when calling SetFromBuffer on Pipeline")
+			}
+			msg := fmt.Sprint(r)
+			if !strings.Contains(msg, "Pipeline") {
+				t.Fatalf("panic = %q", msg)
+			}
+		}()
+		// this should panic per the policy
+		_ = p.SetFromBuffer(context.Background(), "k", []byte("v"))
+	})
+
+	t.Run("txpipeline panic", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		client := mock.NewClient(ctrl)
+		adapter := NewAdapter(client)
+
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("expected panic when calling SetFromBuffer on TxPipeline")
+			}
+			msg := fmt.Sprint(r)
+			if !strings.Contains(msg, "TxPipeline") {
+				t.Fatalf("panic = %q", msg)
+			}
+		}()
+		// this should panic per the policy
+		_ = adapter.TxPipeline().SetFromBuffer(context.Background(), "k", []byte("v"))
+	})
+}
+
+// Integration tests that require a live Valkey server running on localhost:6379.
+// These are skipped automatically if no server is reachable.
+func TestSetFromBuffer_Integration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress:  []string{"127.0.0.1:6378"},
+		DisableRetry: true,
+		Dialer:       net.Dialer{Timeout: time.Second},
+	})
+	if err != nil {
+		t.Skipf("no server on 6378: %v", err)
+	}
+	defer client.Close()
+
+	adapter := NewAdapter(client)
+	// Use Ping as a reliable skip gate (some NewClient setups don't verify)
+	if err := adapter.Ping(ctx).Err(); err != nil {
+		t.Skipf("no server on 6378: %v", err)
+	}
+
+	t.Run("Live Binary Payload", func(t *testing.T) {
+		key := "int-sfb-binary"
+		payload := []byte{0x00, 0x01, 0xFF, 0xFE, 0xFD}
+
+		if err := adapter.SetFromBuffer(ctx, key, payload).Err(); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+
+		res, err := adapter.Get(ctx, key).Bytes()
+		if err != nil {
+			t.Fatalf("expected nil error during Get, got %v", err)
+		}
+
+		if !bytes.Equal(payload, res) {
+			t.Fatalf("expected %v, got %v", payload, res)
+		}
+	})
+
+	t.Run("Live Empty Buffer", func(t *testing.T) {
+		key := "int-sfb-empty"
+		payload := []byte{}
+
+		if err := adapter.SetFromBuffer(ctx, key, payload).Err(); err != nil {
+			t.Fatalf("expected nil error on empty buffer, got %v", err)
+		}
+
+		res, err := adapter.Get(ctx, key).Bytes()
+		if err != nil {
+			t.Fatalf("expected nil error during Get, got %v", err)
+		}
+
+		if len(res) != 0 {
+			t.Fatalf("expected empty response, got length %d", len(res))
+		}
+	})
+
+	t.Run("Live Overwrite", func(t *testing.T) {
+		key := "int-sfb-overwrite"
+
+		// Set initial value
+		adapter.Set(ctx, key, "initial-data", 0)
+
+		// Overwrite from buffer
+		newPayload := []byte("overwritten-data")
+		if err := adapter.SetFromBuffer(ctx, key, newPayload).Err(); err != nil {
+			t.Fatalf("expected nil error on overwrite, got %v", err)
+		}
+
+		res, _ := adapter.Get(ctx, key).Bytes()
+		if !bytes.Equal(newPayload, res) {
+			t.Fatalf("expected %v, got %v", newPayload, res)
+		}
+	})
 }
 
 var (

--- a/valkeycompat/adapter_test.go
+++ b/valkeycompat/adapter_test.go
@@ -2074,6 +2074,16 @@ func testAdapter(resp3 bool) {
 			Expect(get.Val()).To(Equal("hello"))
 		})
 
+		It("should SetFromBuffer", func() {
+			set := adapter.SetFromBuffer(ctx, "key", []byte("hello"))
+			Expect(set.Err()).NotTo(HaveOccurred())
+			Expect(set.Val()).To(Equal("OK"))
+
+			get := adapter.Get(ctx, "key")
+			Expect(get.Err()).NotTo(HaveOccurred())
+			Expect(get.Val()).To(Equal("hello"))
+		})
+
 		It("should SetEX", func() {
 			err := adapter.SetEX(ctx, "key", "hello", 1*time.Second).Err()
 			Expect(err).NotTo(HaveOccurred())

--- a/valkeycompat/pipeline.go
+++ b/valkeycompat/pipeline.go
@@ -464,6 +464,12 @@ func (c *Pipeline) SetRange(ctx context.Context, key string, offset int64, value
 	return ret
 }
 
+// SetFromBuffer is not supported for Pipeline because it performs a zero-copy
+// conversion of the provided buffer to string which cannot be safely deferred.
+func (c *Pipeline) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
+	panic("SetFromBuffer is not supported in Pipeline (zero-copy buffer conversion)")
+}
+
 func (c *Pipeline) StrLen(ctx context.Context, key string) *IntCmd {
 	ret := c.comp.StrLen(ctx, key)
 	c.rets = append(c.rets, ret)

--- a/valkeycompat/pipeline.go
+++ b/valkeycompat/pipeline.go
@@ -468,6 +468,12 @@ func (c *Pipeline) SetRange(ctx context.Context, key string, offset int64, value
 	return ret
 }
 
+func (c *Pipeline) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
+	ret := c.comp.SetFromBuffer(ctx, key, buf)
+	c.rets = append(c.rets, ret)
+	return ret
+}
+
 func (c *Pipeline) StrLen(ctx context.Context, key string) *IntCmd {
 	ret := c.comp.StrLen(ctx, key)
 	c.rets = append(c.rets, ret)

--- a/valkeycompat/pipeline_test.go
+++ b/valkeycompat/pipeline_test.go
@@ -202,6 +202,7 @@ func TestPipeliner(t *testing.T) {
 		p.MSetNX(ctx, 1, 2)
 		p.Set(ctx, "1", 2, time.Second)
 		p.SetArgs(ctx, "1", 2, SetArgs{})
+		p.SetFromBuffer(ctx, "1", []byte("3"))
 		p.SetEX(ctx, "1", 2, time.Second)
 		p.SetNX(ctx, "1", 2, time.Second)
 		p.SetXX(ctx, "1", 2, time.Second)
@@ -641,7 +642,7 @@ func TestPipeliner(t *testing.T) {
 			Args: []any{"1", "2"},
 		})
 
-		if n := len(p.rets); n != 492 {
+		if n := len(p.rets); n != 493 {
 			t.Fatalf("unexpected pipeline calls: %v", n)
 		}
 		for i, cmd := range p.rets {
@@ -649,7 +650,7 @@ func TestPipeliner(t *testing.T) {
 				t.Fatalf("unexpected pipeline placeholder err(%d): %v", i, err)
 			}
 		}
-		if n := len(p.comp.client.(*proxy).cmds); n != 492 {
+		if n := len(p.comp.client.(*proxy).cmds); n != 493 {
 			t.Fatalf("unexpected pipeline commands: %v", n)
 		}
 		var pipeline [][]string
@@ -739,6 +740,7 @@ var golden = `[
     ["MSETNX","1","2"],
     ["SET","1","2","EX","1"],
     ["SET","1","2"],
+    ["SET","1","3"],
     ["SETEX","1","1","2"],
     ["SET","1","2","NX","EX","1"],
     ["SET","1","2","XX","EX","1"],

--- a/valkeycompat/tx.go
+++ b/valkeycompat/tx.go
@@ -147,3 +147,10 @@ func (t *tx) Close(_ context.Context) error {
 	t.cancel()
 	return nil
 }
+
+// SetFromBuffer is intentionally unsupported in TxPipeline for the same
+// reasons as Pipeline.SetFromBuffer: zero-copy buffer conversions cannot be
+// safely deferred. Panic to make misuse explicit.
+func (c *TxPipeline) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
+	panic("SetFromBuffer is not supported in TxPipeline (zero-copy buffer conversion)")
+}

--- a/valkeycompat/tx.go
+++ b/valkeycompat/tx.go
@@ -148,12 +148,10 @@ func (t *tx) Close(_ context.Context) error {
 	return nil
 }
 
-func (c *TxPipeline) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
-	return c.rePipeline.SetFromBuffer(ctx, key, buf)
-}
-
 func (c *TxPipeline) GetToBuffer(ctx context.Context, key string, buf []byte) *ZeroCopyStringCmd {
 	panic("GetToBuffer is not supported in TxPipeline")
 }
 
-
+func (c *TxPipeline) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
+	return c.rePipeline.SetFromBuffer(ctx, key, buf)
+}

--- a/valkeycompat/tx.go
+++ b/valkeycompat/tx.go
@@ -148,6 +148,12 @@ func (t *tx) Close(_ context.Context) error {
 	return nil
 }
 
+func (c *TxPipeline) SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd {
+	return c.rePipeline.SetFromBuffer(ctx, key, buf)
+}
+
 func (c *TxPipeline) GetToBuffer(ctx context.Context, key string, buf []byte) *ZeroCopyStringCmd {
 	panic("GetToBuffer is not supported in TxPipeline")
 }
+
+


### PR DESCRIPTION
****PR Description:** ## Summary**

Adds ⁠ SetFromBuffer ⁠ to ⁠ valkeycompat ⁠ so the go-redis adapter matches
go-redis v9.21+.

⁠ Compat.Set ⁠ already accepts ⁠ []byte ⁠, but ⁠ str() ⁠ copies. This path uses
⁠ valkey.BinaryString(buf) ⁠ and issues a plain ⁠ SET key value ⁠ with no TTL.

**## API**
SetFromBuffer(ctx context.Context, key string, buf []byte) *StatusCmd

**Signed-off-by**: Amrita Kumari kumariam@google.com
**Co-authored-by**: Omkar Mestry omanges@google.com