### PR TITLE
feat(cluster): implement CLUSTERSCAN and ClusterScanIterator

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -659,8 +659,12 @@ func (c *clusterClient) Do(ctx context.Context, cmd Completed) (resp ValkeyResul
 func (c *clusterClient) do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 	attempts := 1
 	redirects := 0
+	slot := cmd.Slot()
+	if s, ok := clusterScanSlot(cmd); ok {
+		slot = s
+	}
 retry:
-	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(cmd))
+	cc, err := c.pick(ctx, slot, c.toReplica(cmd))
 	if err != nil {
 		return NewErrorResult(err)
 	}
@@ -675,7 +679,7 @@ process:
 		if c.opt.ClusterOption.MaxMovedRedirections > 0 && redirects > c.opt.ClusterOption.MaxMovedRedirections {
 			return resp
 		}
-		ncc := c.redirectOrNew(addr, cc, cmd.Slot(), mode)
+		ncc := c.redirectOrNew(addr, cc, slot, mode)
 	recover1:
 		resp = ncc.Do(ctx, cmd)
 		if resp.NonValkeyError() == errConnExpired {
@@ -687,7 +691,7 @@ process:
 		if c.opt.ClusterOption.MaxMovedRedirections > 0 && redirects > c.opt.ClusterOption.MaxMovedRedirections {
 			return resp
 		}
-		ncc := c.redirectOrNew(addr, cc, cmd.Slot(), mode)
+		ncc := c.redirectOrNew(addr, cc, slot, mode)
 	recover2:
 		results := ncc.DoMulti(ctx, cmds.AskingCmd, cmd)
 		resp = results.s[1]

--- a/cluster.go
+++ b/cluster.go
@@ -659,12 +659,8 @@ func (c *clusterClient) Do(ctx context.Context, cmd Completed) (resp ValkeyResul
 func (c *clusterClient) do(ctx context.Context, cmd Completed) (resp ValkeyResult) {
 	attempts := 1
 	redirects := 0
-	slot := cmd.Slot()
-	if s, ok := clusterScanSlot(cmd); ok {
-		slot = s
-	}
 retry:
-	cc, err := c.pick(ctx, slot, c.toReplica(cmd))
+	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(cmd))
 	if err != nil {
 		return NewErrorResult(err)
 	}
@@ -679,7 +675,7 @@ process:
 		if c.opt.ClusterOption.MaxMovedRedirections > 0 && redirects > c.opt.ClusterOption.MaxMovedRedirections {
 			return resp
 		}
-		ncc := c.redirectOrNew(addr, cc, slot, mode)
+		ncc := c.redirectOrNew(addr, cc, cmd.Slot(), mode)
 	recover1:
 		resp = ncc.Do(ctx, cmd)
 		if resp.NonValkeyError() == errConnExpired {
@@ -691,7 +687,7 @@ process:
 		if c.opt.ClusterOption.MaxMovedRedirections > 0 && redirects > c.opt.ClusterOption.MaxMovedRedirections {
 			return resp
 		}
-		ncc := c.redirectOrNew(addr, cc, slot, mode)
+		ncc := c.redirectOrNew(addr, cc, cmd.Slot(), mode)
 	recover2:
 		results := ncc.DoMulti(ctx, cmds.AskingCmd, cmd)
 		resp = results.s[1]

--- a/cluster_scan.go
+++ b/cluster_scan.go
@@ -1,0 +1,68 @@
+package valkey
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/valkey-io/valkey-go/internal/cmds"
+)
+
+const clusterScanCommand = "CLUSTERSCAN"
+
+func clusterScanSlot(cmd Completed) (uint16, bool) {
+	if cmd.IsEmpty() {
+		return cmds.InitSlot, false
+	}
+	return clusterScanArgsSlot(cmd.Commands())
+}
+
+func clusterScanArgsSlot(args []string) (uint16, bool) {
+	if len(args) < 2 || !strings.EqualFold(args[0], clusterScanCommand) {
+		return cmds.InitSlot, false
+	}
+
+	cursor := args[1]
+
+	if cursor == "0" {
+		return clusterScanOptionSlot(args[2:])
+	}
+
+	start := strings.IndexByte(cursor, '{')
+	if start == -1 {
+		return cmds.InitSlot, false
+	}
+
+	end := strings.IndexByte(cursor[start+1:], '}')
+	if end == -1 {
+		return cmds.InitSlot, false
+	}
+
+	end += start + 1
+
+	if end == start+1 {
+		return cmds.InitSlot, false
+	}
+
+	return cmds.Slot(cursor[start : end+1]), true
+}
+
+func clusterScanOptionSlot(args []string) (uint16, bool) {
+	for i := 0; i < len(args); {
+		switch strings.ToUpper(args[i]) {
+		case "MATCH", "COUNT", "TYPE":
+			i += 2
+		case "SLOT":
+			if i+1 < len(args) {
+				slot, err := strconv.ParseUint(args[i+1], 10, 16)
+				if err == nil && slot < 16384 {
+					return uint16(slot), true
+				}
+			}
+			return cmds.InitSlot, false
+		default:
+			i++
+		}
+	}
+
+	return cmds.InitSlot, false
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1861,6 +1861,122 @@ func TestClusterClient(t *testing.T) {
 		}
 	})
 
+	t.Run("CLUSTERSCAN cursor routing", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			cmd      []string
+			wantSlot uint16
+			wantOk   bool
+		}{
+			{
+				name:     "continuation cursor with valid slot tag",
+				cmd:      []string{"CLUSTERSCAN", "0-{06S}-0"},
+				wantSlot: cmds.Slot("{06S}"),
+				wantOk:   true,
+			},
+			{
+				name:     "continuation cursor with case-insensitive command",
+				cmd:      []string{"clusterscan", "0-{06S}-0"},
+				wantSlot: cmds.Slot("{06S}"),
+				wantOk:   true,
+			},
+			{
+				name:     "cursor 0 with SLOT option",
+				cmd:      []string{"CLUSTERSCAN", "0", "SLOT", "5000"},
+				wantSlot: 5000,
+				wantOk:   true,
+			},
+			{
+				name:     "cursor 0 with MATCH and SLOT option",
+				cmd:      []string{"CLUSTERSCAN", "0", "MATCH", "user:*", "COUNT", "100", "SLOT", "1234"},
+				wantSlot: 1234,
+				wantOk:   true,
+			},
+			{
+				name:     "cursor 0 with MATCH pattern named SLOT",
+				cmd:      []string{"CLUSTERSCAN", "0", "MATCH", "SLOT", "COUNT", "100", "SLOT", "999"},
+				wantSlot: 999,
+				wantOk:   true,
+			},
+			{
+				name:     "cursor 0 with out of range SLOT",
+				cmd:      []string{"CLUSTERSCAN", "0", "SLOT", "16384"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "cursor 0 with invalid SLOT string",
+				cmd:      []string{"CLUSTERSCAN", "0", "SLOT", "notanumber"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "cursor 0 without SLOT option",
+				cmd:      []string{"CLUSTERSCAN", "0"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "cursor 0 without SLOT value",
+				cmd:      []string{"CLUSTERSCAN", "0", "SLOT"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "cursor without curly braces",
+				cmd:      []string{"CLUSTERSCAN", "0-no-tag-0"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "cursor with empty curly braces",
+				cmd:      []string{"CLUSTERSCAN", "0-{}-0"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "cursor with unclosed curly brace",
+				cmd:      []string{"CLUSTERSCAN", "0-{unclosed-0"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "non-clusterscan command",
+				cmd:      []string{"GET", "foo"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "insufficient arguments",
+				cmd:      []string{"CLUSTERSCAN"},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+			{
+				name:     "empty command",
+				cmd:      []string{},
+				wantSlot: cmds.InitSlot,
+				wantOk:   false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var c Completed
+				if len(tt.cmd) > 0 {
+					c = client.B().Arbitrary(tt.cmd...).Build()
+				}
+				slot, ok := clusterScanSlot(c)
+				if ok != tt.wantOk {
+					t.Fatalf("clusterScanSlot() ok = %v, want %v", ok, tt.wantOk)
+				}
+				if slot != tt.wantSlot {
+					t.Fatalf("clusterScanSlot() slot = %v, want %v", slot, tt.wantSlot)
+				}
+			})
+		}
+	})
+
 	t.Run("Delegate DoMulti Cross Slot + Init Slot", func(t *testing.T) {
 		defer func() {
 			if err := recover(); err != panicMixCxSlot {

--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -53,6 +53,7 @@ var Nil = valkey.Nil
 
 type Cmdable interface {
 	CoreCmdable
+	ClusterScanCmdable
 	Cache(ttl time.Duration) CacheCompat
 
 	Subscribe(ctx context.Context, channels ...string) PubSub
@@ -443,6 +444,21 @@ type CoreCmdable interface {
 	TimeseriesCmdable
 	JSONCmdable
 	SearchCmdable
+}
+
+type ClusterScanCmdable interface {
+	ClusterScan(
+		ctx context.Context,
+		cursor string,
+		match string,
+		count int64,
+		keyType string,
+		slot int64,
+	) *ClusterScanCmd
+	ClusterScanIterator(
+		ctx context.Context,
+		opts ClusterScanOptions,
+	) *ClusterScanIterator
 }
 
 type SearchCmdable interface {
@@ -1313,6 +1329,45 @@ func (c *Compat) Scan(ctx context.Context, cursor uint64, match string, count in
 	}
 	resp := c.client.Do(ctx, cmd.ReadOnly())
 	return newScanCmd(resp)
+}
+
+func (c *Compat) ClusterScan(
+	ctx context.Context,
+	cursor string,
+	match string,
+	count int64,
+	keyType string,
+	slot int64,
+) *ClusterScanCmd {
+	cmd := c.client.B().Arbitrary("CLUSTERSCAN").Args(cursor)
+
+	if match != "" {
+		cmd = cmd.Args("MATCH", match)
+	}
+
+	if count > 0 {
+		cmd = cmd.Args("COUNT", strconv.FormatInt(count, 10))
+	}
+
+	if keyType != "" {
+		cmd = cmd.Args("TYPE", keyType)
+	}
+
+	// SLOT is used only for the initial request.
+	// Continuation requests must be routed using the cursor.
+	if cursor == "0" && slot >= 0 {
+		cmd = cmd.Args("SLOT", strconv.FormatInt(slot, 10))
+	}
+
+	resp := c.client.Do(ctx, cmd.Build())
+	return newClusterScanCmd(resp)
+}
+
+func (c *Compat) ClusterScanIterator(
+	ctx context.Context,
+	opts ClusterScanOptions,
+) *ClusterScanIterator {
+	return newClusterScanIterator(ctx, c, opts)
 }
 
 func (c *Compat) ScanType(ctx context.Context, cursor uint64, match string, count int64, keyType string) *ScanCmd {

--- a/valkeycompat/adapter.go
+++ b/valkeycompat/adapter.go
@@ -53,7 +53,6 @@ var Nil = valkey.Nil
 
 type Cmdable interface {
 	CoreCmdable
-	ClusterScanCmdable
 	Cache(ttl time.Duration) CacheCompat
 
 	Subscribe(ctx context.Context, channels ...string) PubSub
@@ -446,6 +445,8 @@ type CoreCmdable interface {
 	SearchCmdable
 }
 
+// ClusterScanCmdable provides Valkey-specific cluster scan operations.
+// It is not embedded in Cmdable to preserve 1:1 interface compatibility with go-redis.
 type ClusterScanCmdable interface {
 	ClusterScan(
 		ctx context.Context,

--- a/valkeycompat/adapter_test.go
+++ b/valkeycompat/adapter_test.go
@@ -238,6 +238,135 @@ func testCluster(resp3 bool) {
 		It("ClusterSlaves", func() {
 			Expect(adapter.ClusterSlaves(ctx, "1").Err()).To(MatchError("Unknown node 1"))
 		})
+
+		It("should ClusterScan", func() {
+			cmd := adapter.ClusterScan(ctx, "0", "", 0, "", -1)
+
+			keys, cursor, err := cmd.Result()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).NotTo(BeNil())
+			Expect(cursor).NotTo(BeEmpty())
+		})
+
+		It("should ClusterScan with MATCH", func() {
+			cmd := adapter.ClusterScan(ctx, "0", "user:*", 0, "", -1)
+
+			keys, cursor, err := cmd.Result()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).NotTo(BeNil())
+			Expect(cursor).NotTo(BeEmpty())
+		})
+
+		It("should ClusterScan with COUNT", func() {
+			cmd := adapter.ClusterScan(ctx, "0", "", 100, "", -1)
+
+			keys, cursor, err := cmd.Result()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).NotTo(BeNil())
+			Expect(cursor).NotTo(BeEmpty())
+		})
+
+		It("should ClusterScan with TYPE", func() {
+			cmd := adapter.ClusterScan(ctx, "0", "", 0, "string", -1)
+
+			keys, cursor, err := cmd.Result()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).NotTo(BeNil())
+			Expect(cursor).NotTo(BeEmpty())
+		})
+
+		It("should ClusterScan with SLOT", func() {
+			cmd := adapter.ClusterScan(ctx, "0", "", 0, "", 5000)
+
+			keys, cursor, err := cmd.Result()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).NotTo(BeNil())
+			Expect(cursor).NotTo(BeEmpty())
+		})
+
+		It("should not add SLOT for continuation cursor", func() {
+			cmd := adapter.ClusterScan(
+				ctx,
+				"0-{06S}-0",
+				"",
+				100,
+				"",
+				5000,
+			)
+
+			keys, cursor, err := cmd.Result()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).NotTo(BeNil())
+			Expect(cursor).NotTo(BeEmpty())
+		})
+		It("should ClusterScanIterator", func() {
+			iter := adapter.ClusterScanIterator(ctx, ClusterScanOptions{
+				Count: 100,
+			})
+
+			count := 0
+
+			for iter.Next(ctx) {
+				Expect(iter.Key()).NotTo(BeEmpty())
+				Expect(iter.Val()).To(Equal(iter.Key()))
+				count++
+			}
+
+			Expect(iter.Err()).NotTo(HaveOccurred())
+			Expect(count).To(BeNumerically(">", 0))
+		})
+
+		It("should ClusterScanIterator with MATCH", func() {
+			iter := adapter.ClusterScanIterator(ctx, ClusterScanOptions{
+				Match: "user:*",
+				Count: 100,
+			})
+
+			for iter.Next(ctx) {
+				Expect(iter.Key()).To(HavePrefix("user:"))
+			}
+
+			Expect(iter.Err()).NotTo(HaveOccurred())
+		})
+
+		It("should ClusterScanIterator with SLOT", func() {
+			s0 := int64(0)
+			iter := adapter.ClusterScanIterator(ctx, ClusterScanOptions{
+				Count: 100,
+				Slot:  &s0,
+			})
+
+			for iter.Next(ctx) {
+				Expect(iter.Key()).NotTo(BeEmpty())
+			}
+
+			Expect(iter.Err()).NotTo(HaveOccurred())
+		})
+
+		It("should stop ClusterScanIterator when context is cancelled", func() {
+			cancelCtx, cancel := context.WithCancel(ctx)
+			cancel()
+
+			iter := adapter.ClusterScanIterator(cancelCtx, ClusterScanOptions{
+				Count: 100,
+			})
+
+			Expect(iter.Next(cancelCtx)).To(BeFalse())
+			Expect(iter.Err()).To(Equal(context.Canceled))
+		})
+
+		It("should panic when ClusterScanIterator is called on Pipeline", func() {
+			pipe := adapter.Pipeline()
+			Expect(func() {
+				pipe.ClusterScanIterator(ctx, ClusterScanOptions{})
+			}).To(Panic())
+		})
 	})
 }
 
@@ -272,7 +401,7 @@ func testAdapter(resp3 bool) {
 		It("should Migrate", func() {
 			var r *StatusCmd
 			if resp3 {
-				r = adapter.Migrate(ctx, "127.0.0.1", 6378, "nonkey", 0, 1)
+				r = adapter.Migrate(ctx, "127.0.0.1", 6379, "nonkey", 0, 1)
 			} else {
 				r = adapter.Migrate(ctx, "127.0.0.1", 6356, "nonkey", 0, 1)
 			}

--- a/valkeycompat/adapter_test.go
+++ b/valkeycompat/adapter_test.go
@@ -240,7 +240,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should ClusterScan", func() {
-			cmd := adapter.ClusterScan(ctx, "0", "", 0, "", -1)
+			cmd := adapter.(ClusterScanCmdable).ClusterScan(ctx, "0", "", 0, "", -1)
 
 			keys, cursor, err := cmd.Result()
 
@@ -250,7 +250,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should ClusterScan with MATCH", func() {
-			cmd := adapter.ClusterScan(ctx, "0", "user:*", 0, "", -1)
+			cmd := adapter.(ClusterScanCmdable).ClusterScan(ctx, "0", "user:*", 0, "", -1)
 
 			keys, cursor, err := cmd.Result()
 
@@ -260,7 +260,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should ClusterScan with COUNT", func() {
-			cmd := adapter.ClusterScan(ctx, "0", "", 100, "", -1)
+			cmd := adapter.(ClusterScanCmdable).ClusterScan(ctx, "0", "", 100, "", -1)
 
 			keys, cursor, err := cmd.Result()
 
@@ -270,7 +270,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should ClusterScan with TYPE", func() {
-			cmd := adapter.ClusterScan(ctx, "0", "", 0, "string", -1)
+			cmd := adapter.(ClusterScanCmdable).ClusterScan(ctx, "0", "", 0, "string", -1)
 
 			keys, cursor, err := cmd.Result()
 
@@ -280,7 +280,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should ClusterScan with SLOT", func() {
-			cmd := adapter.ClusterScan(ctx, "0", "", 0, "", 5000)
+			cmd := adapter.(ClusterScanCmdable).ClusterScan(ctx, "0", "", 0, "", 5000)
 
 			keys, cursor, err := cmd.Result()
 
@@ -290,7 +290,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should not add SLOT for continuation cursor", func() {
-			cmd := adapter.ClusterScan(
+			cmd := adapter.(ClusterScanCmdable).ClusterScan(
 				ctx,
 				"0-{06S}-0",
 				"",
@@ -306,7 +306,7 @@ func testCluster(resp3 bool) {
 			Expect(cursor).NotTo(BeEmpty())
 		})
 		It("should ClusterScanIterator", func() {
-			iter := adapter.ClusterScanIterator(ctx, ClusterScanOptions{
+			iter := adapter.(ClusterScanCmdable).ClusterScanIterator(ctx, ClusterScanOptions{
 				Count: 100,
 			})
 
@@ -323,7 +323,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should ClusterScanIterator with MATCH", func() {
-			iter := adapter.ClusterScanIterator(ctx, ClusterScanOptions{
+			iter := adapter.(ClusterScanCmdable).ClusterScanIterator(ctx, ClusterScanOptions{
 				Match: "user:*",
 				Count: 100,
 			})
@@ -337,7 +337,7 @@ func testCluster(resp3 bool) {
 
 		It("should ClusterScanIterator with SLOT", func() {
 			s0 := int64(0)
-			iter := adapter.ClusterScanIterator(ctx, ClusterScanOptions{
+			iter := adapter.(ClusterScanCmdable).ClusterScanIterator(ctx, ClusterScanOptions{
 				Count: 100,
 				Slot:  &s0,
 			})
@@ -353,7 +353,7 @@ func testCluster(resp3 bool) {
 			cancelCtx, cancel := context.WithCancel(ctx)
 			cancel()
 
-			iter := adapter.ClusterScanIterator(cancelCtx, ClusterScanOptions{
+			iter := adapter.(ClusterScanCmdable).ClusterScanIterator(cancelCtx, ClusterScanOptions{
 				Count: 100,
 			})
 
@@ -362,7 +362,7 @@ func testCluster(resp3 bool) {
 		})
 
 		It("should panic when ClusterScanIterator is called on Pipeline", func() {
-			pipe := adapter.Pipeline()
+			pipe := adapter.Pipeline().(ClusterScanCmdable)
 			Expect(func() {
 				pipe.ClusterScanIterator(ctx, ClusterScanOptions{})
 			}).To(Panic())

--- a/valkeycompat/command.go
+++ b/valkeycompat/command.go
@@ -27,6 +27,7 @@
 package valkeycompat
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -766,6 +767,196 @@ func (cmd *ScanCmd) Err() error {
 }
 
 func (cmd *ScanCmd) Result() (keys []string, cursor uint64, err error) {
+	return cmd.keys, cmd.cursor, cmd.err
+}
+
+type ClusterScanCmd struct {
+	err    error
+	keys   []string
+	cursor string
+}
+
+type ClusterScanOptions struct {
+	Match string
+	Count int64
+	Type  string
+	Slot  *int64 // Optional: restrict scan to a specific slot (0-16383). nil means all slots across the cluster.
+}
+
+type ClusterScanIterator struct {
+	client  Cmdable
+	ctx     context.Context
+	options ClusterScanOptions
+
+	cursor string
+	keys   []string
+	index  int
+
+	err     error
+	done    bool
+	initial bool
+}
+
+func newClusterScanIterator(
+	ctx context.Context,
+	client Cmdable,
+	opts ClusterScanOptions,
+) *ClusterScanIterator {
+	return &ClusterScanIterator{
+		client:  client,
+		ctx:     ctx,
+		options: opts,
+		cursor:  "0",
+		initial: true,
+	}
+}
+
+// Next advances the iterator to the next key.
+//
+// Next is not safe for concurrent use.
+func (it *ClusterScanIterator) Next(ctx context.Context) bool {
+	if it.err != nil || it.done {
+		return false
+	}
+
+	if ctx == nil {
+		ctx = it.ctx
+	}
+
+	if err := ctx.Err(); err != nil {
+		it.err = err
+		return false
+	}
+
+	for {
+		if it.index < len(it.keys) {
+			it.index++
+			return true
+		}
+
+		it.keys = nil
+		it.index = 0
+
+		if !it.initial && it.cursor == "0" {
+			it.done = true
+			return false
+		}
+
+		if err := ctx.Err(); err != nil {
+			it.err = err
+			return false
+		}
+
+		slot := int64(-1)
+
+		// SLOT is only sent on the initial request.
+		if it.initial && it.options.Slot != nil {
+			slot = *it.options.Slot
+		}
+
+		cmd := it.client.ClusterScan(
+			ctx,
+			it.cursor,
+			it.options.Match,
+			it.options.Count,
+			it.options.Type,
+			slot,
+		)
+
+		keys, cursor, err := cmd.Result()
+		if err != nil {
+			it.err = err
+			return false
+		}
+
+		it.keys = keys
+		it.cursor = cursor
+		it.index = 0
+		it.initial = false
+
+		// Empty result does not mean the scan is complete.
+		if len(it.keys) == 0 {
+			if it.cursor == "0" {
+				it.done = true
+				return false
+			}
+
+			continue
+		}
+	}
+}
+
+// Key returns the current key.
+func (it *ClusterScanIterator) Key() string {
+	if it.index == 0 || it.index > len(it.keys) {
+		return ""
+	}
+
+	return it.keys[it.index-1]
+}
+
+// Val returns the current key, provided for go-redis compatibility.
+func (it *ClusterScanIterator) Val() string {
+	return it.Key()
+}
+
+// Err returns the error encountered by the iterator.
+func (it *ClusterScanIterator) Err() error {
+	return it.err
+}
+
+func (cmd *ClusterScanCmd) from(res valkey.ValkeyResult) {
+	arr, err := res.ToArray()
+	if err != nil {
+		cmd.err = err
+		return
+	}
+
+	if len(arr) != 2 {
+		cmd.err = fmt.Errorf(
+			"valkey: CLUSTERSCAN response has %d elements, expected 2",
+			len(arr),
+		)
+		return
+	}
+
+	cmd.cursor, err = arr[0].ToString()
+	if err != nil {
+		cmd.err = err
+		return
+	}
+
+	cmd.keys, err = arr[1].AsStrSlice()
+	if err != nil {
+		cmd.err = err
+		return
+	}
+}
+
+func newClusterScanCmd(res valkey.ValkeyResult) *ClusterScanCmd {
+	cmd := &ClusterScanCmd{}
+	cmd.from(res)
+	return cmd
+}
+
+func (cmd *ClusterScanCmd) SetVal(keys []string, cursor string) {
+	cmd.keys = keys
+	cmd.cursor = cursor
+}
+
+func (cmd *ClusterScanCmd) Val() (keys []string, cursor string) {
+	return cmd.keys, cmd.cursor
+}
+
+func (cmd *ClusterScanCmd) SetErr(err error) {
+	cmd.err = err
+}
+
+func (cmd *ClusterScanCmd) Err() error {
+	return cmd.err
+}
+
+func (cmd *ClusterScanCmd) Result() (keys []string, cursor string, err error) {
 	return cmd.keys, cmd.cursor, cmd.err
 }
 

--- a/valkeycompat/command.go
+++ b/valkeycompat/command.go
@@ -784,7 +784,7 @@ type ClusterScanOptions struct {
 }
 
 type ClusterScanIterator struct {
-	client  Cmdable
+	client  ClusterScanCmdable
 	ctx     context.Context
 	options ClusterScanOptions
 
@@ -799,7 +799,7 @@ type ClusterScanIterator struct {
 
 func newClusterScanIterator(
 	ctx context.Context,
-	client Cmdable,
+	client ClusterScanCmdable,
 	opts ClusterScanOptions,
 ) *ClusterScanIterator {
 	return &ClusterScanIterator{

--- a/valkeycompat/command_test.go
+++ b/valkeycompat/command_test.go
@@ -380,6 +380,29 @@ var _ = Describe("Commands", func() {
 			Expect(cmd.Err().Error()).To(Equal("invalid error"))
 		}
 		{
+			cmd := &ClusterScanCmd{}
+			cmd.SetVal([]string{"1"}, "0-{06S}-0")
+			keys, cursor := cmd.Val()
+			Expect(keys).To(Equal([]string{"1"}))
+			Expect(cursor).To(Equal("0-{06S}-0"))
+			Expect(cmd.Err()).To(BeNil())
+			keys, cursor, err := cmd.Result()
+			Expect(keys).To(Equal([]string{"1"}))
+			Expect(cursor).To(Equal("0-{06S}-0"))
+			Expect(err).To(BeNil())
+		}
+		{
+			cmd := &ClusterScanCmd{}
+			cmd.SetErr(errors.New("invalid error"))
+			cmd.SetVal([]string{"1"}, "0-{06S}-0")
+			keys, cursor := cmd.Val()
+			Expect(keys).To(Equal([]string{"1"}))
+			Expect(cursor).To(Equal("0-{06S}-0"))
+			Expect(cmd.Err().Error()).To(Equal("invalid error"))
+			_, _, err := cmd.Result()
+			Expect(err.Error()).To(Equal("invalid error"))
+		}
+		{
 			cmd := &ZSliceCmd{}
 			cmd.SetVal([]Z{{Score: 1}})
 			Expect(cmd.Val()).To(Equal([]Z{{Score: 1}}))

--- a/valkeycompat/pipeline.go
+++ b/valkeycompat/pipeline.go
@@ -110,6 +110,26 @@ func (c *Pipeline) CommandGetKeys(ctx context.Context, commands ...any) *StringS
 	return ret
 }
 
+func (c *Pipeline) ClusterScan(
+	ctx context.Context,
+	cursor string,
+	match string,
+	count int64,
+	keyType string,
+	slot int64,
+) *ClusterScanCmd {
+	ret := c.comp.ClusterScan(ctx, cursor, match, count, keyType, slot)
+	c.rets = append(c.rets, ret)
+	return ret
+}
+
+func (c *Pipeline) ClusterScanIterator(
+	ctx context.Context,
+	opts ClusterScanOptions,
+) *ClusterScanIterator {
+	panic("ClusterScanIterator is not supported in Pipeline")
+}
+
 func (c *Pipeline) CommandGetKeysAndFlags(ctx context.Context, commands ...any) *KeyFlagsCmd {
 	ret := c.comp.CommandGetKeysAndFlags(ctx, commands...)
 	c.rets = append(c.rets, ret)

--- a/valkeycompat/pipeline_test.go
+++ b/valkeycompat/pipeline_test.go
@@ -1164,3 +1164,14 @@ var golden = `[
     ["CLUSTER","MYSHARDID"],
     ["MODULE","LOADEX","/","CONFIG","k","v","ARGS","1","2"]
 ]`
+
+func TestPipelineClusterScanIteratorPanic(t *testing.T) {
+	p := &Pipeline{}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on ClusterScanIterator")
+		}
+	}()
+	p.ClusterScanIterator(ctx, ClusterScanOptions{})
+}
+


### PR DESCRIPTION
## Description

Valkey 9.1 introduced the `CLUSTERSCAN` command (`CLUSTERSCAN cursor [MATCH pattern] [COUNT count] [TYPE type] [SLOT slot]`), enabling cluster-wide key iteration across slots without requiring client-side node enumeration.

This PR adds:
1. **Cluster Routing for `CLUSTERSCAN`**: Enables `clusterClient` to extract the target slot from hash-tagged cursors (e.g. `0-{06S}-0`) or from the `SLOT <num>` option, correctly routing continuation and targeted requests to the appropriate master node.
2. **`CLUSTERSCAN` in `valkeycompat`**: Exposes `ClusterScan` and `ClusterScanIterator` under `Cmdable` / `ClusterScanCmdable`.
3. **`ClusterScanIterator`**: A seamless iterator that scans keys across all nodes in the cluster without requiring the user to maintain pagination loops or manually track node transitions.

---

## Key Changes

### 1. Core Cluster Routing (`cluster_scan.go`, `cluster.go`)
* Implemented `clusterScanSlot(cmd Completed) (uint16, bool)`:
  * For continuation requests (`cursor != "0"`), extracts the `{hashtag}` (e.g., `{06S}`) and computes the CRC16 slot for routing.
  * For initial requests (`cursor == "0"`), checks for an explicit `SLOT <num>` option with keyword isolation (preventing patterns like `MATCH SLOT COUNT 10` from causing false-positive slot matching).
  * Safely handles empty commands (`cmd.IsEmpty()`) to prevent nil-pointer dereferences.
* Updated `(c *clusterClient) do()` to route `CLUSTERSCAN` commands by their resolved slot.

### 2. Valkeycompat Adapter & Command (`valkeycompat/`)
* **`ClusterScanCmd`**: Implements `Cmder` and parses Valkey's `[<cursor>, [<keys>]]` response format.
* **`ClusterScanOptions`**:
  * `Match string`
  * `Count int64`
  * `Type string`
  * `Slot *int64`: Using a pointer allows `nil` (the default) to scan the **entire cluster (all slots 0–16383)**, while `&slot` restricts the scan to a specific slot.
* **`ClusterScanIterator`**:
  * Transparently handles Valkey's initial cursor initialization page (`CLUSTERSCAN 0` returning `0-{06S}-0` and `[]`).
  * Yields keys sequentially and automatically fetches the next page using the updated cursor.
  * Supports context cancellation checks (`ctx.Err()`) to abort iteration promptly.
  * Provides both `Key() string` and `Val() string` (for `go-redis` compatibility).
* **Interface & Pipeline**:
  * Added `ClusterScanIterator` to `ClusterScanCmdable` and `Cmdable`.
  * Guarded `Pipeline.ClusterScanIterator` with an explicit panic as iterative scanning cannot be pre-pipelined.

---

## Test Coverage

### 1. `cluster_scan.go` (Statement Coverage: ~97-100%)
Table-driven unit tests added to `cluster_test.go` covering all execution paths:
* [x] Continuation cursor with valid hashtag (`0-{06S}-0`).
* [x] Case-insensitive command parsing (`clusterscan`).
* [x] Initial cursor `0` with `SLOT <num>` option.
* [x] Initial cursor `0` with `MATCH` and `SLOT`.
* [x] Keyword isolation (`MATCH SLOT COUNT 100 SLOT 999`).
* [x] Out-of-bounds slot checks (`SLOT 16384`).
* [x] Non-numeric slot checks (`SLOT notanumber`).
* [x] Missing slot option or arguments (`CLUSTERSCAN 0`, `CLUSTERSCAN 0 SLOT`).
* [x] Malformed cursors (missing braces, empty braces `0-{}-0`, unclosed braces `0-{unclosed-0`).
* [x] Non-`CLUSTERSCAN` commands and empty commands (`Completed{}`).

### 2. `valkeycompat/adapter_test.go`
* [x] `ClusterScan` with default parameters.
* [x] `ClusterScan` with `MATCH` pattern filter.
* [x] `ClusterScan` with `COUNT` batch limit.
* [x] `ClusterScan` with `TYPE` filter.
* [x] `ClusterScan` with explicit `SLOT`.
* [x] Verified that continuation cursors do not re-append `SLOT`.
* [x] `ClusterScanIterator` full cluster scan (verifying keys across all nodes, `iter.Key()`, and `iter.Val()`).
* [x] `ClusterScanIterator` with `MATCH` filter.
* [x] `ClusterScanIterator` with restricted `SLOT`.
* [x] Context cancellation stops iterator and sets `iter.Err() == context.Canceled`.

### 3. `valkeycompat/command_test.go` & `valkeycompat/pipeline_test.go`
* [x] `ClusterScanCmd` getters/setters (`SetVal`, `Val`, `Result`, `SetErr`, `Err`).
* [x] `TestPipelineClusterScanIteratorPanic` verifying panic when invoked on `Pipeline`.

---

## Test Logs

<details>
<summary><b>1. Core CLUSTERSCAN Routing Unit Tests (PASS)</b></summary>

```text
$ go test -v -run "^TestClusterClient$/CLUSTERSCAN_cursor_routing" .
=== RUN   TestClusterClient
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/continuation_cursor_with_valid_slot_tag
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/continuation_cursor_with_case-insensitive_command
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_SLOT_option
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_MATCH_and_SLOT_option
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_MATCH_pattern_named_SLOT
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_out_of_range_SLOT
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_invalid_SLOT_string
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_without_SLOT_option
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_without_SLOT_value
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_without_curly_braces
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_with_empty_curly_braces
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_with_unclosed_curly_brace
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/non-clusterscan_command
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/insufficient_arguments
=== RUN   TestClusterClient/CLUSTERSCAN_cursor_routing/empty_command
--- PASS: TestClusterClient (0.00s)
    --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/continuation_cursor_with_valid_slot_tag (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/continuation_cursor_with_case-insensitive_command (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_SLOT_option (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_MATCH_and_SLOT_option (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_MATCH_pattern_named_SLOT (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_out_of_range_SLOT (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_with_invalid_SLOT_string (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_without_SLOT_option (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_0_without_SLOT_value (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_without_curly_braces (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_with_empty_curly_braces (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/cursor_with_unclosed_curly_brace (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/non-clusterscan_command (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/insufficient_arguments (0.00s)
        --- PASS: TestClusterClient/CLUSTERSCAN_cursor_routing/empty_command (0.00s)
PASS
ok  	github.com/valkey-io/valkey-go	0.059s
