### PR TITLE
provide ser/de funcs with context and cache key

### DIFF
--- a/valkeyaside/typed_aside.go
+++ b/valkeyaside/typed_aside.go
@@ -17,8 +17,8 @@ type TypedCacheAsideClient[T any] interface {
 // It provides a typed cache-aside client that allows caching and retrieving values of a specific type T.
 type typedCacheAsideClient[T any] struct {
 	client       CacheAsideClient
-	serializer   func(*T) (string, error)
-	deserializer func(string) (*T, error)
+	serializer   func(context.Context, string, *T) (string, error)
+	deserializer func(context.Context, string, string) (*T, error)
 }
 
 // NewTypedCacheAsideClient creates a new TypedCacheAsideClient instance that provides a typed cache-aside client.
@@ -29,6 +29,26 @@ func NewTypedCacheAsideClient[T any](
 	client CacheAsideClient,
 	serializer func(*T) (string, error),
 	deserializer func(string) (*T, error),
+) TypedCacheAsideClient[T] {
+	return &typedCacheAsideClient[T]{
+		client: client,
+		serializer: func(ctx context.Context, key string, val *T) (string, error) {
+			return serializer(val)
+		},
+		deserializer: func(ctx context.Context, key string, str string) (*T, error) {
+			return deserializer(str)
+		},
+	}
+}
+
+// NewTypedCacheAsideClientWithContext creates a new TypedCacheAsideClient instance that provides a typed cache-aside client.
+// The client, serializer, and deserializer functions are used to interact with the underlying cache.
+// The serializer function is used to convert the provided value of type T to a string, and the deserializer function
+// is used to convert the cached string value back to the original type T.
+func NewTypedCacheAsideClientWithContext[T any](
+	client CacheAsideClient,
+	serializer func(context.Context, string, *T) (string, error),
+	deserializer func(context.Context, string, string) (*T, error),
 ) TypedCacheAsideClient[T] {
 	return &typedCacheAsideClient[T]{
 		client:       client,
@@ -46,12 +66,12 @@ func (c typedCacheAsideClient[T]) Get(ctx context.Context, ttl time.Duration, ke
 		if err != nil {
 			return "", err
 		}
-		return c.serializer(result)
+		return c.serializer(ctx, key, result)
 	})
 	if err != nil {
 		return nil, err
 	}
-	return c.deserializer(strVal)
+	return c.deserializer(ctx, key, strVal)
 }
 
 // Del deletes the value associated with the given key from the cache.

--- a/valkeyaside/typed_aside.go
+++ b/valkeyaside/typed_aside.go
@@ -41,19 +41,25 @@ func NewTypedCacheAsideClient[T any](
 	}
 }
 
+// TypedCodec converts values of type T to and from their cached string form.
+// Both functions receive the context and cache key of the in-flight Get.
+type TypedCodec[T any] struct {
+	Marshal   func(ctx context.Context, key string, val *T) (string, error)
+	Unmarshal func(ctx context.Context, key string, str string) (*T, error)
+}
+
 // NewTypedCacheAsideClientWithContext creates a new TypedCacheAsideClient instance that provides a typed cache-aside client.
 // The client, serializer, and deserializer functions are used to interact with the underlying cache.
 // The serializer function is used to convert the provided value of type T to a string, and the deserializer function
 // is used to convert the cached string value back to the original type T.
-func NewTypedCacheAsideClientWithContext[T any](
+func NewTypedCacheAsideClientWithCodec[T any](
 	client CacheAsideClient,
-	serializer func(context.Context, string, *T) (string, error),
-	deserializer func(context.Context, string, string) (*T, error),
+	codec TypedCodec[T],
 ) TypedCacheAsideClient[T] {
 	return &typedCacheAsideClient[T]{
 		client:       client,
-		serializer:   serializer,
-		deserializer: deserializer,
+		serializer:   codec.Marshal,
+		deserializer: codec.Unmarshal,
 	}
 }
 

--- a/valkeyaside/typed_aside.go
+++ b/valkeyaside/typed_aside.go
@@ -48,9 +48,11 @@ type TypedCodec[T any] struct {
 	Unmarshal func(ctx context.Context, key string, str string) (*T, error)
 }
 
-// NewTypedCacheAsideClientWithContext creates a new TypedCacheAsideClient instance that provides a typed cache-aside client.
-// The client, serializer, and deserializer functions are used to interact with the underlying cache.
-// The serializer function is used to convert the provided value of type T to a string, and the deserializer function
+// NewTypedCacheAsideClientWithCodec creates a new TypedCacheAsideClient
+// instance that provides a typed cache-aside client.
+// The client and codec are used to interact with the underlying cache.
+// The codec's Marshal function is used to convert the provided value of type T
+// to a string, and the codec's Unmarshal function
 // is used to convert the cached string value back to the original type T.
 func NewTypedCacheAsideClientWithCodec[T any](
 	client CacheAsideClient,

--- a/valkeyaside/typed_aside_test.go
+++ b/valkeyaside/typed_aside_test.go
@@ -227,37 +227,39 @@ func TestTypedCacheAsideClientWithCodec_Get(t *testing.T) {
 	serializerCalls := 0
 	deserializerCalls := 0
 
-	serializer := func(ctx context.Context, gotKey string, val *testStruct) (string, error) {
-		serializerCalls++
-		if got, want := ctx.Value(requestContextKey), "populate"; got != want {
-			t.Errorf("serializer context value = %v, want %v", got, want)
-		}
-		if gotKey != key {
-			t.Errorf("serializer key = %q, want %q", gotKey, key)
-		}
-		bytes, err := json.Marshal(val)
-		return string(bytes), err
-	}
-	deserializer := func(ctx context.Context, gotKey, str string) (*testStruct, error) {
-		deserializerCalls++
-		wantContext := "populate"
-		if deserializerCalls == 2 {
-			wantContext = "cached"
-		}
-		if got := ctx.Value(requestContextKey); got != wantContext {
-			t.Errorf("deserializer context value = %v, want %v", got, wantContext)
-		}
-		if gotKey != key {
-			t.Errorf("deserializer key = %q, want %q", gotKey, key)
-		}
-		var val testStruct
-		if err := json.Unmarshal([]byte(str), &val); err != nil {
-			return nil, err
-		}
-		return &val, nil
+	codec := TypedCodec[testStruct]{
+		Marshal: func(ctx context.Context, gotKey string, val *testStruct) (string, error) {
+			serializerCalls++
+			if got, want := ctx.Value(requestContextKey), "populate"; got != want {
+				t.Errorf("serializer context value = %v, want %v", got, want)
+			}
+			if gotKey != key {
+				t.Errorf("serializer key = %q, want %q", gotKey, key)
+			}
+			bytes, err := json.Marshal(val)
+			return string(bytes), err
+		},
+		Unmarshal: func(ctx context.Context, gotKey, str string) (*testStruct, error) {
+			deserializerCalls++
+			wantContext := "populate"
+			if deserializerCalls == 2 {
+				wantContext = "cached"
+			}
+			if got := ctx.Value(requestContextKey); got != wantContext {
+				t.Errorf("deserializer context value = %v, want %v", got, wantContext)
+			}
+			if gotKey != key {
+				t.Errorf("deserializer key = %q, want %q", gotKey, key)
+			}
+			var val testStruct
+			if err := json.Unmarshal([]byte(str), &val); err != nil {
+				return nil, err
+			}
+			return &val, nil
+		},
 	}
 
-	client := NewTypedCacheAsideClientWithCodec[testStruct](baseClient, TypedCodec[testStruct]{Marshal: serializer, Unmarshal: deserializer})
+	client := NewTypedCacheAsideClientWithCodec[testStruct](baseClient, codec)
 
 	val, err := client.Get(context.WithValue(context.Background(), requestContextKey, "populate"), time.Second, key, func(ctx context.Context, gotKey string) (*testStruct, error) {
 		if got := ctx.Value(requestContextKey); got != "populate" {

--- a/valkeyaside/typed_aside_test.go
+++ b/valkeyaside/typed_aside_test.go
@@ -43,7 +43,6 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 		val, err := client.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 			return expected, nil
 		})
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -98,7 +97,6 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 		val, err := client.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 			return nil, nil
 		})
-
 		if err != nil {
 			t.Fatalf("nil value should not return error: %v", err)
 		}
@@ -112,18 +110,18 @@ func TestTypedCacheAsideClient_Del(t *testing.T) {
 	baseClient := makeClient(t, addr)
 	t.Cleanup(baseClient.Close)
 
-	serializer := func(v *testStruct) (string, error) {
+	serializer := func(_ context.Context, _ string, v *testStruct) (string, error) {
 		b, err := json.Marshal(v)
 		return string(b), err
 	}
 
-	deserializer := func(s string) (*testStruct, error) {
+	deserializer := func(_ context.Context, _ string, s string) (*testStruct, error) {
 		var v testStruct
 		err := json.Unmarshal([]byte(s), &v)
 		return &v, err
 	}
 
-	client := NewTypedCacheAsideClient[testStruct](baseClient, serializer, deserializer)
+	client := NewTypedCacheAsideClientWithContext[testStruct](baseClient, serializer, deserializer)
 
 	// Set a value first
 	key := randStr()

--- a/valkeyaside/typed_aside_test.go
+++ b/valkeyaside/typed_aside_test.go
@@ -216,7 +216,7 @@ func TestTypedCacheAsideClient_OverrideTTL(t *testing.T) {
 	})
 }
 
-func TestTypedCacheAsideClientWithContext_Get(t *testing.T) {
+func TestTypedCacheAsideClientWithCodec_Get(t *testing.T) {
 	baseClient := makeClient(t, addr)
 	t.Cleanup(baseClient.Close)
 
@@ -257,7 +257,7 @@ func TestTypedCacheAsideClientWithContext_Get(t *testing.T) {
 		return &val, nil
 	}
 
-	client := NewTypedCacheAsideClientWithContext[testStruct](baseClient, serializer, deserializer)
+	client := NewTypedCacheAsideClientWithCodec[testStruct](baseClient, TypedCodec[testStruct]{Marshal: serializer, Unmarshal: deserializer})
 
 	val, err := client.Get(context.WithValue(context.Background(), requestContextKey, "populate"), time.Second, key, func(ctx context.Context, gotKey string) (*testStruct, error) {
 		if got := ctx.Value(requestContextKey); got != "populate" {

--- a/valkeyaside/typed_aside_test.go
+++ b/valkeyaside/typed_aside_test.go
@@ -110,18 +110,18 @@ func TestTypedCacheAsideClient_Del(t *testing.T) {
 	baseClient := makeClient(t, addr)
 	t.Cleanup(baseClient.Close)
 
-	serializer := func(_ context.Context, _ string, v *testStruct) (string, error) {
+	serializer := func(v *testStruct) (string, error) {
 		b, err := json.Marshal(v)
 		return string(b), err
 	}
 
-	deserializer := func(_ context.Context, _ string, s string) (*testStruct, error) {
+	deserializer := func(s string) (*testStruct, error) {
 		var v testStruct
 		err := json.Unmarshal([]byte(s), &v)
 		return &v, err
 	}
 
-	client := NewTypedCacheAsideClientWithContext[testStruct](baseClient, serializer, deserializer)
+	client := NewTypedCacheAsideClient[testStruct](baseClient, serializer, deserializer)
 
 	// Set a value first
 	key := randStr()
@@ -214,4 +214,81 @@ func TestTypedCacheAsideClient_OverrideTTL(t *testing.T) {
 			t.Fatalf("expected %v, got %v", found, val)
 		}
 	})
+}
+
+func TestTypedCacheAsideClientWithContext_Get(t *testing.T) {
+	baseClient := makeClient(t, addr)
+	t.Cleanup(baseClient.Close)
+
+	type contextKey string
+	const requestContextKey contextKey = "request"
+	key := randStr()
+	expected := &testStruct{ID: 1, Name: "test"}
+	serializerCalls := 0
+	deserializerCalls := 0
+
+	serializer := func(ctx context.Context, gotKey string, val *testStruct) (string, error) {
+		serializerCalls++
+		if got, want := ctx.Value(requestContextKey), "populate"; got != want {
+			t.Errorf("serializer context value = %v, want %v", got, want)
+		}
+		if gotKey != key {
+			t.Errorf("serializer key = %q, want %q", gotKey, key)
+		}
+		bytes, err := json.Marshal(val)
+		return string(bytes), err
+	}
+	deserializer := func(ctx context.Context, gotKey, str string) (*testStruct, error) {
+		deserializerCalls++
+		wantContext := "populate"
+		if deserializerCalls == 2 {
+			wantContext = "cached"
+		}
+		if got := ctx.Value(requestContextKey); got != wantContext {
+			t.Errorf("deserializer context value = %v, want %v", got, wantContext)
+		}
+		if gotKey != key {
+			t.Errorf("deserializer key = %q, want %q", gotKey, key)
+		}
+		var val testStruct
+		if err := json.Unmarshal([]byte(str), &val); err != nil {
+			return nil, err
+		}
+		return &val, nil
+	}
+
+	client := NewTypedCacheAsideClientWithContext[testStruct](baseClient, serializer, deserializer)
+
+	val, err := client.Get(context.WithValue(context.Background(), requestContextKey, "populate"), time.Second, key, func(ctx context.Context, gotKey string) (*testStruct, error) {
+		if got := ctx.Value(requestContextKey); got != "populate" {
+			t.Errorf("fetch context value = %v, want %v", got, "populate")
+		}
+		if gotKey != key {
+			t.Errorf("fetch key = %q, want %q", gotKey, key)
+		}
+		return expected, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *val != *expected {
+		t.Fatalf("value = %v, want %v", val, expected)
+	}
+
+	cached, err := client.Get(context.WithValue(context.Background(), requestContextKey, "cached"), time.Second, key, func(context.Context, string) (*testStruct, error) {
+		t.Fatal("fetch function should not be called for a cached value")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *cached != *expected {
+		t.Fatalf("cached value = %v, want %v", cached, expected)
+	}
+	if serializerCalls != 1 {
+		t.Errorf("serializer calls = %d, want 1", serializerCalls)
+	}
+	if deserializerCalls != 2 {
+		t.Errorf("deserializer calls = %d, want 2", deserializerCalls)
+	}
 }


### PR DESCRIPTION
I have used this construct in my work projects for doing things like talking to telemetry and/or memoizing the deserialization with an in-memory object cache.