### PR TITLE
valkeylimiter: implement atomic GCRA Lua engine and response parser

### DIFF
--- a/valkeylimiter/limiter.go
+++ b/valkeylimiter/limiter.go
@@ -3,6 +3,7 @@ package valkeylimiter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -181,3 +182,225 @@ end
 local current = redis.call("incrby", rate_limit_key, increment_amount)
 return { current, expires_at }
 `)
+
+// GCRAResult contains the raw numeric and timing results returned by the GCRA Lua engine.
+type GCRAResult struct {
+	Allowed    int64
+	Remaining  int64
+	RetryAfter time.Duration
+	ResetAfter time.Duration
+}
+
+// DurFromSecString parses a float-in-seconds string (e.g., "-1", "0.1", "1.5") into a time.Duration.
+// A value of -1 returns time.Duration(-1), indicating no retry wait is needed.
+func DurFromSecString(s string) (time.Duration, error) {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	if f == -1 {
+		return -1, nil
+	}
+	if f < 0 {
+		return 0, nil
+	}
+	return time.Duration(f * float64(time.Second)), nil
+}
+
+// ParseGCRAResponse parses the 4-element array response from the GCRA Lua scripts.
+// The array format is:
+// [0] allowed (int64): count of allowed tokens (0 if rejected, or cost if allowed)
+// [1] remaining (int64): maximum permitted instantaneous tokens
+// [2] retry_after (string): float seconds until next request permitted ("-1" if allowed)
+// [3] reset_after (string): float seconds until full rate limit restoration
+func ParseGCRAResponse(resp valkey.ValkeyResult) (GCRAResult, error) {
+	if err := resp.Error(); err != nil {
+		return GCRAResult{}, err
+	}
+
+	arr, err := resp.ToArray()
+	if err != nil || len(arr) != 4 {
+		return GCRAResult{}, ErrInvalidResponse
+	}
+
+	allowed, err := arr[0].AsInt64()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid allowed count: %v", ErrInvalidResponse, err)
+	}
+
+	remaining, err := arr[1].AsInt64()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid remaining count: %v", ErrInvalidResponse, err)
+	}
+
+	retryStr, err := arr[2].ToString()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid retry_after: %v", ErrInvalidResponse, err)
+	}
+	retryAfter, err := DurFromSecString(retryStr)
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: failed to parse retry_after %q: %v", ErrInvalidResponse, retryStr, err)
+	}
+
+	resetStr, err := arr[3].ToString()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid reset_after: %v", ErrInvalidResponse, err)
+	}
+	resetAfter, err := DurFromSecString(resetStr)
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: failed to parse reset_after %q: %v", ErrInvalidResponse, resetStr, err)
+	}
+
+	return GCRAResult{
+		Allowed:    allowed,
+		Remaining:  remaining,
+		RetryAfter: retryAfter,
+		ResetAfter: resetAfter,
+	}, nil
+}
+
+func ExecGCRAAllowN(ctx context.Context, client valkey.Client, key string, burst int64, rate int64, period time.Duration, cost int64) (GCRAResult, error) {
+	resp := gcraAllowNScript.Exec(ctx, client, []string{key}, []string{
+		strconv.FormatInt(burst, 10),
+		strconv.FormatInt(rate, 10),
+		strconv.FormatFloat(period.Seconds(), 'f', -1, 64),
+		strconv.FormatInt(cost, 10),
+	})
+	return ParseGCRAResponse(resp)
+}
+
+func ExecGCRAAllowAtMost(ctx context.Context, client valkey.Client, key string, burst int64, rate int64, period time.Duration, cost int64) (GCRAResult, error) {
+	resp := gcraAllowAtMostScript.Exec(ctx, client, []string{key}, []string{
+		strconv.FormatInt(burst, 10),
+		strconv.FormatInt(rate, 10),
+		strconv.FormatFloat(period.Seconds(), 'f', -1, 64),
+		strconv.FormatInt(cost, 10),
+	})
+	return ParseGCRAResponse(resp)
+}
+
+// gcraAllowNScript implements the atomic GCRA allowN (all-or-nothing) algorithm in Lua.
+// KEYS[1]: rate limit key
+// ARGV[1]: burst tolerance count
+// ARGV[2]: rate (number of operations per period)
+// ARGV[3]: period in seconds
+// ARGV[4]: cost (tokens requested)
+var gcraAllowNScript = valkey.NewLuaScript(`
+redis.replicate_commands()
+
+local rate_limit_key = KEYS[1]
+local burst = tonumber(ARGV[1])
+local rate = tonumber(ARGV[2])
+local period = tonumber(ARGV[3])
+local cost = tonumber(ARGV[4])
+
+local emission_interval = period / rate
+local increment = emission_interval * cost
+local burst_offset = emission_interval * burst
+
+local jan_1_2017 = 1483228800
+local now = redis.call("TIME")
+now = (now[1] - jan_1_2017) + (now[2] / 1000000)
+
+local tat = redis.call("GET", rate_limit_key)
+
+if not tat then
+  tat = now
+else
+  tat = tonumber(tat)
+end
+
+tat = math.max(tat, now)
+
+local diff = burst_offset - increment - (tat - now)
+local remaining = diff / emission_interval
+
+if remaining < 0 then
+  local reset_after = tat - now
+  local retry_after = diff * -1
+  return {
+    0,
+    0,
+    tostring(retry_after),
+    tostring(reset_after),
+  }
+end
+
+local new_tat = tat + increment
+local reset_after = new_tat - now
+if reset_after > 0 then
+  redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+end
+local retry_after = -1
+return {cost, math.floor(remaining + 1e-9), tostring(retry_after), tostring(reset_after)}
+`)
+
+// gcraAllowAtMostScript implements the atomic GCRA allowAtMost (partial grant) algorithm in Lua.
+// KEYS[1]: rate limit key
+// ARGV[1]: burst tolerance count
+// ARGV[2]: rate (number of operations per period)
+// ARGV[3]: period in seconds
+// ARGV[4]: cost (maximum tokens requested)
+var gcraAllowAtMostScript = valkey.NewLuaScript(`
+redis.replicate_commands()
+
+local rate_limit_key = KEYS[1]
+local burst = tonumber(ARGV[1])
+local rate = tonumber(ARGV[2])
+local period = tonumber(ARGV[3])
+local cost = tonumber(ARGV[4])
+
+local emission_interval = period / rate
+local burst_offset = emission_interval * burst
+
+local jan_1_2017 = 1483228800
+local now = redis.call("TIME")
+now = (now[1] - jan_1_2017) + (now[2] / 1000000)
+
+local tat = redis.call("GET", rate_limit_key)
+
+if not tat then
+  tat = now
+else
+  tat = tonumber(tat)
+end
+
+tat = math.max(tat, now)
+
+local diff = burst_offset - (tat - now)
+local remaining = diff / emission_interval
+
+if remaining < 1 then
+  local reset_after = tat - now
+  local retry_after = emission_interval - diff
+  return {
+    0,
+    0,
+    tostring(retry_after),
+    tostring(reset_after),
+  }
+end
+
+if remaining < cost then
+  cost = remaining
+  remaining = 0
+else
+  remaining = remaining - cost
+end
+
+local increment = emission_interval * cost
+local new_tat = tat + increment
+
+local reset_after = new_tat - now
+if reset_after > 0 then
+  redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+end
+
+return {
+  cost,
+  math.floor(remaining + 1e-9),
+  tostring(-1),
+  tostring(reset_after),
+}
+`)
+

--- a/valkeylimiter/limiter_test.go
+++ b/valkeylimiter/limiter_test.go
@@ -457,3 +457,332 @@ func BenchmarkAllowN(b *testing.B) {
 		}
 	}
 }
+
+func TestDurFromSecString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:  "negative one represents no retry",
+			input: "-1",
+			want:  -1,
+		},
+		{
+			name:  "zero seconds",
+			input: "0",
+			want:  0,
+		},
+		{
+			name:  "fractional seconds 100ms",
+			input: "0.1",
+			want:  100 * time.Millisecond,
+		},
+		{
+			name:  "one second",
+			input: "1.0",
+			want:  time.Second,
+		},
+		{
+			name:  "multi second float",
+			input: "2.5",
+			want:  2500 * time.Millisecond,
+		},
+		{
+			name:  "negative number other than -1",
+			input: "-0.5",
+			want:  0,
+		},
+		{
+			name:    "invalid float string",
+			input:   "not-a-number",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := valkeylimiter.DurFromSecString(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("DurFromSecString(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("DurFromSecString(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGCRAResponse(t *testing.T) {
+	t.Run("success allowed", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+		))
+
+		got, err := valkeylimiter.ParseGCRAResponse(resp)
+		if err != nil {
+			t.Fatalf("ParseGCRAResponse() unexpected error: %v", err)
+		}
+
+		want := valkeylimiter.GCRAResult{
+			Allowed:    1,
+			Remaining:  9,
+			RetryAfter: -1,
+			ResetAfter: 100 * time.Millisecond,
+		}
+		if got != want {
+			t.Fatalf("ParseGCRAResponse() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("success rejected", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(0),
+			mock.ValkeyInt64(0),
+			mock.ValkeyString("0.5"),
+			mock.ValkeyString("1.0"),
+		))
+
+		got, err := valkeylimiter.ParseGCRAResponse(resp)
+		if err != nil {
+			t.Fatalf("ParseGCRAResponse() unexpected error: %v", err)
+		}
+
+		want := valkeylimiter.GCRAResult{
+			Allowed:    0,
+			Remaining:  0,
+			RetryAfter: 500 * time.Millisecond,
+			ResetAfter: time.Second,
+		}
+		if got != want {
+			t.Fatalf("ParseGCRAResponse() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("valkey error", func(t *testing.T) {
+		resp := mock.ErrorResult(errors.New("valkey cluster error"))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if err == nil {
+			t.Fatal("ParseGCRAResponse() expected error, got nil")
+		}
+	})
+
+	t.Run("invalid non-array response", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyString("unexpected string"))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid array length less than 4", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid array length greater than 4", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+			mock.ValkeyString("extra"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid first element (not int64 or int string)", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyString("not-an-int"),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid second element (not int64 or int string)", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyString("not-an-int"),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid retry_after float string", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("invalid-float"),
+			mock.ValkeyString("0.1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid reset_after float string", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("invalid-float"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+}
+
+func TestExecGCRAAllowN_Mock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(2),
+		mock.ValkeyInt64(8),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.2"),
+	))).Times(1)
+
+	got, err := valkeylimiter.ExecGCRAAllowN(context.Background(), client, "rate:{user:1}", 10, 10, time.Second, 2)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN() unexpected error: %v", err)
+	}
+
+	want := valkeylimiter.GCRAResult{
+		Allowed:    2,
+		Remaining:  8,
+		RetryAfter: -1,
+		ResetAfter: 200 * time.Millisecond,
+	}
+	if got != want {
+		t.Fatalf("ExecGCRAAllowN() = %+v, want %+v", got, want)
+	}
+}
+
+func TestExecGCRAAllowAtMost_Mock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(4),
+		mock.ValkeyInt64(0),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.6"),
+	))).Times(1)
+
+	got, err := valkeylimiter.ExecGCRAAllowAtMost(context.Background(), client, "rate:{user:2}", 10, 10, time.Second, 5)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowAtMost() unexpected error: %v", err)
+	}
+
+	want := valkeylimiter.GCRAResult{
+		Allowed:    4,
+		Remaining:  0,
+		RetryAfter: -1,
+		ResetAfter: 600 * time.Millisecond,
+	}
+	if got != want {
+		t.Fatalf("ExecGCRAAllowAtMost() = %+v, want %+v", got, want)
+	}
+}
+
+func TestGCRA_LiveServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live server test in short mode")
+	}
+
+	client, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress: []string{"127.0.0.1:6378"},
+	})
+	if err != nil {
+		t.Skipf("cannot connect to 127.0.0.1:6378: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	testKey := fmt.Sprintf("test:gcra:live:%d", time.Now().UnixNano())
+
+	// Clean up key after test
+	defer func() {
+		_ = client.Do(ctx, client.B().Del().Key(testKey).Build()).Error()
+	}()
+
+	// Test AllowN: Limit 10 req / 1 sec, burst 10
+	// 1. Initial request for 1 token: should succeed, allowed = 1, remaining = 9
+	res1, err := valkeylimiter.ExecGCRAAllowN(ctx, client, testKey, 10, 10, time.Second, 1)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN 1st call error: %v", err)
+	}
+	if res1.Allowed != 1 || res1.Remaining != 9 || res1.RetryAfter != -1 {
+		t.Fatalf("ExecGCRAAllowN 1st call unexpected result: %+v", res1)
+	}
+
+	// 2. Request for 2 tokens: should succeed, allowed = 2, remaining = 7
+	res2, err := valkeylimiter.ExecGCRAAllowN(ctx, client, testKey, 10, 10, time.Second, 2)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN 2nd call error: %v", err)
+	}
+	if res2.Allowed != 2 || res2.Remaining != 7 || res2.RetryAfter != -1 {
+		t.Fatalf("ExecGCRAAllowN 2nd call unexpected result: %+v", res2)
+	}
+
+	// 3. Request exceeding remaining tokens with AllowN (cost 100): should be rejected all-or-nothing
+	res3, err := valkeylimiter.ExecGCRAAllowN(ctx, client, testKey, 10, 10, time.Second, 100)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN 3rd call error: %v", err)
+	}
+	if res3.Allowed != 0 || res3.Remaining != 0 || res3.RetryAfter <= 0 {
+		t.Fatalf("ExecGCRAAllowN 3rd call should be rejected: %+v", res3)
+	}
+
+	// 4. Test AllowAtMost with 7 remaining, asking for 10: should grant 7
+	res4, err := valkeylimiter.ExecGCRAAllowAtMost(ctx, client, testKey, 10, 10, time.Second, 10)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowAtMost error: %v", err)
+	}
+	if res4.Allowed != 7 || res4.Remaining != 0 || res4.RetryAfter != -1 {
+		t.Fatalf("ExecGCRAAllowAtMost unexpected result: %+v", res4)
+	}
+
+	// 5. Test AllowAtMost when exhausted: should be rejected
+	res5, err := valkeylimiter.ExecGCRAAllowAtMost(ctx, client, testKey, 10, 10, time.Second, 1)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowAtMost exhausted error: %v", err)
+	}
+	if res5.Allowed != 0 || res5.Remaining != 0 || res5.RetryAfter <= 0 {
+		t.Fatalf("ExecGCRAAllowAtMost exhausted should be rejected: %+v", res5)
+	}
+}
+


### PR DESCRIPTION
## Title: valkeylimiter: implement atomic GCRA Lua engine and response parser

### Summary
This PR implements the core Generic Cell Rate Algorithm (GCRA / virtual leaky bucket) Lua engine and response parsing logic in `valkeylimiter`. 

### Key Changes
1. **Atomic GCRA Lua Scripts (`gcraAllowNScript` & `gcraAllowAtMostScript`)**:
   - Implements continuous rate limiting with Theoretical Arrival Time (TAT) and burst tolerance ($\tau = \text{Burst} \times T$).
   - Supports both all-or-nothing consumption (`allowN`) and partial grant semantics (`allowAtMost`).
   - Dynamically manages key TTL via `EX math.ceil(reset_after)` for automatic cleanup of idle keys.
2. **Server-Side Authoritative Clock**:
   - Evaluates current time exclusively using `redis.call("TIME")` inside Valkey, eliminating client-side NTP clock drift across Kubernetes pods/VMs.
3. **Single-Key Architecture for Valkey Cluster Safety**:
   - Operates strictly on a single key (`KEYS[1]`), ensuring out-of-the-box cluster compatibility with zero chance of `CROSSSLOT` errors.
4. **Numerical Stability (Catastrophic Cancellation Fix)**:
   - Formulates timing delta against debt `(tat - now)` with small epsilon rounding (`1e-9`), preventing 64-bit float precision loss on large epoch timestamps.
5. **Response Parser & Unpacker**:
   - Decodes the 4-element Lua array (`[allowed, remaining, retry_after, reset_after]`) into `GCRAResult`.
   - `DurFromSecString` converts fractional second strings to `time.Duration`, with `-1` mapped to `time.Duration(-1)`.
6. **Zero New Files Created**:
   - All logic and test suites are consolidated into existing files: `valkeylimiter/limiter.go` and `valkeylimiter/limiter_test.go`.

---

### Test Logs

```bash
$ go test -v -run 'Test(Dur|Parse|Exec|GCRA)' ./...
=== RUN   TestDurFromSecString
=== RUN   TestDurFromSecString/negative_one_represents_no_retry
=== RUN   TestDurFromSecString/zero_seconds
=== RUN   TestDurFromSecString/fractional_seconds_100ms
=== RUN   TestDurFromSecString/one_second
=== RUN   TestDurFromSecString/multi_second_float
=== RUN   TestDurFromSecString/negative_number_other_than_-1
=== RUN   TestDurFromSecString/invalid_float_string
--- PASS: TestDurFromSecString (0.00s)
    --- PASS: TestDurFromSecString/negative_one_represents_no_retry (0.00s)
    --- PASS: TestDurFromSecString/zero_seconds (0.00s)
    --- PASS: TestDurFromSecString/fractional_seconds_100ms (0.00s)
    --- PASS: TestDurFromSecString/one_second (0.00s)
    --- PASS: TestDurFromSecString/multi_second_float (0.00s)
    --- PASS: TestDurFromSecString/negative_number_other_than_-1 (0.00s)
    --- PASS: TestDurFromSecString/invalid_float_string (0.00s)
=== RUN   TestParseGCRAResponse
=== RUN   TestParseGCRAResponse/success_allowed
=== RUN   TestParseGCRAResponse/success_rejected
=== RUN   TestParseGCRAResponse/valkey_error
=== RUN   TestParseGCRAResponse/invalid_non-array_response
=== RUN   TestParseGCRAResponse/invalid_array_length_less_than_4
=== RUN   TestParseGCRAResponse/invalid_array_length_greater_than_4
=== RUN   TestParseGCRAResponse/invalid_first_element_(not_int64_or_int_string)
=== RUN   TestParseGCRAResponse/invalid_second_element_(not_int64_or_int_string)
=== RUN   TestParseGCRAResponse/invalid_retry_after_float_string
=== RUN   TestParseGCRAResponse/invalid_reset_after_float_string
--- PASS: TestParseGCRAResponse (0.00s)
    --- PASS: TestParseGCRAResponse/success_allowed (0.00s)
    --- PASS: TestParseGCRAResponse/success_rejected (0.00s)
    --- PASS: TestParseGCRAResponse/valkey_error (0.00s)
    --- PASS: TestParseGCRAResponse/invalid_non-array_response (0.00s)
    --- PASS: TestParseGCRAResponse/invalid_array_length_less_than_4 (0.00s)
    --- PASS: TestParseGCRAResponse/invalid_array_length_greater_than_4 (0.00s)
    --- PASS: TestParseGCRAResponse/invalid_first_element_(not_int64_or_int_string) (0.00s)
    --- PASS: TestParseGCRAResponse/invalid_second_element_(not_int64_or_int_string) (0.00s)
    --- PASS: TestParseGCRAResponse/invalid_retry_after_float_string (0.00s)
    --- PASS: TestParseGCRAResponse/invalid_reset_after_float_string (0.00s)
=== RUN   TestExecGCRAAllowN_Mock
--- PASS: TestExecGCRAAllowN_Mock (0.00s)
=== RUN   TestExecGCRAAllowAtMost_Mock
--- PASS: TestExecGCRAAllowAtMost_Mock (0.00s)
=== RUN   TestGCRA_LiveServer
--- PASS: TestGCRA_LiveServer (0.01s)
PASS
ok  	github.com/valkey-io/valkey-go/valkeylimiter	0.045s

$ go test -race -v -run 'Test(Dur|Parse|Exec|GCRA)' ./...
PASS
ok  	github.com/valkey-io/valkey-go/valkeylimiter	1.079s

$ go test -short -v -run 'TestRateLimiter_' ./...
PASS
ok  	github.com/valkey-io/valkey-go/valkeylimiter	0.034s