### PR TITLE
Sonali/valkeycompat redisrate

### DIFF
--- a/valkeycompat/go.mod
+++ b/valkeycompat/go.mod
@@ -6,11 +6,14 @@ replace github.com/valkey-io/valkey-go => ../
 
 replace github.com/valkey-io/valkey-go/mock => ../mock
 
+replace github.com/valkey-io/valkey-go/valkeylimiter => ../valkeylimiter
+
 require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/valkey-io/valkey-go v1.0.77
 	github.com/valkey-io/valkey-go/mock v1.0.77
+	github.com/valkey-io/valkey-go/valkeylimiter v1.0.77
 	go.uber.org/mock v0.6.0
 )
 

--- a/valkeycompat/redisrate/redisrate.go
+++ b/valkeycompat/redisrate/redisrate.go
@@ -1,0 +1,173 @@
+package redisrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+	"github.com/valkey-io/valkey-go/valkeycompat"
+	"github.com/valkey-io/valkey-go/valkeylimiter"
+)
+
+const redisPrefix = "rate:"
+
+var errNilClient = errors.New("redisrate: client is nil")
+
+type Limit struct {
+	Rate   int
+	Burst  int
+	Period time.Duration
+}
+
+func (l Limit) String() string {
+	return fmt.Sprintf("%d req/%s (burst %d)", l.Rate, fmtDur(l.Period), l.Burst)
+}
+
+func (l Limit) IsZero() bool {
+	return l == Limit{}
+}
+
+func fmtDur(d time.Duration) string {
+	switch d {
+	case time.Second:
+		return "s"
+	case time.Minute:
+		return "m"
+	case time.Hour:
+		return "h"
+	}
+	return d.String()
+}
+
+func PerSecond(rate int) Limit {
+	return Limit{
+		Rate:   rate,
+		Period: time.Second,
+		Burst:  rate,
+	}
+}
+
+func PerMinute(rate int) Limit {
+	return Limit{
+		Rate:   rate,
+		Period: time.Minute,
+		Burst:  rate,
+	}
+}
+
+func PerHour(rate int) Limit {
+	return Limit{
+		Rate:   rate,
+		Period: time.Hour,
+		Burst:  rate,
+	}
+}
+
+type Result struct {
+	Limit Limit
+	Allowed int
+	Remaining int
+	RetryAfter time.Duration
+	ResetAfter time.Duration
+}
+
+type Limiter struct {
+	client valkey.Client
+}
+
+func NewLimiter(rdb valkeycompat.Cmdable) *Limiter {
+	if rdb == nil {
+		return &Limiter{}
+	}
+	return &Limiter{
+		client: rdb.Client(),
+	}
+}
+
+func NewLimiterFromClient(client valkey.Client) *Limiter {
+	return &Limiter{
+		client: client,
+	}
+}
+
+func (l Limiter) Allow(ctx context.Context, key string, limit Limit) (*Result, error) {
+	return l.AllowN(ctx, key, limit, 1)
+}
+
+func (l Limiter) AllowN(ctx context.Context, key string, limit Limit, n int) (*Result, error) {
+	if l.client == nil {
+		return nil, errNilClient
+	}
+	burst := limit.Burst
+	if burst <= 0 {
+		burst = limit.Rate
+	}
+	if burst <= 0 {
+		burst = 1
+	}
+
+	res, err := valkeylimiter.ExecGCRAAllowN(
+		ctx,
+		l.client,
+		redisPrefix+key,
+		int64(burst),
+		int64(limit.Rate),
+		limit.Period,
+		int64(n),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Limit:      limit,
+		Allowed:    int(res.Allowed),
+		Remaining:  int(res.Remaining),
+		RetryAfter: res.RetryAfter,
+		ResetAfter: res.ResetAfter,
+	}, nil
+}
+
+func (l Limiter) AllowAtMost(ctx context.Context, key string, limit Limit, n int) (*Result, error) {
+	if l.client == nil {
+		return nil, errNilClient
+	}
+	burst := limit.Burst
+	if burst <= 0 {
+		burst = limit.Rate
+	}
+	if burst <= 0 {
+		burst = 1
+	}
+
+	res, err := valkeylimiter.ExecGCRAAllowAtMost(
+		ctx,
+		l.client,
+		redisPrefix+key,
+		int64(burst),
+		int64(limit.Rate),
+		limit.Period,
+		int64(n),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Limit:      limit,
+		Allowed:    int(res.Allowed),
+		Remaining:  int(res.Remaining),
+		RetryAfter: res.RetryAfter,
+		ResetAfter: res.ResetAfter,
+	}, nil
+}
+
+func (l *Limiter) Reset(ctx context.Context, key string) error {
+	if l.client == nil {
+		return errNilClient
+	}
+	return l.client.Do(ctx, l.client.B().Del().Key(redisPrefix+key).Build()).Error()
+}
+

--- a/valkeycompat/redisrate/redisrate_test.go
+++ b/valkeycompat/redisrate/redisrate_test.go
@@ -1,0 +1,369 @@
+package redisrate_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/valkey-io/valkey-go"
+	"github.com/valkey-io/valkey-go/valkeycompat"
+	"github.com/valkey-io/valkey-go/valkeycompat/redisrate"
+)
+
+func TestRedisrate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Redisrate Suite")
+}
+
+func getTestClient() valkey.Client {
+	addrs := []string{"127.0.0.1:6379", "127.0.0.1:6378"}
+	for _, addr := range addrs {
+		client, err := valkey.NewClient(valkey.ClientOption{InitAddress: []string{addr}})
+		if err == nil {
+			if err := client.Do(context.Background(), client.B().Ping().Build()).Error(); err == nil {
+				return client
+			}
+			client.Close()
+		}
+	}
+	return nil
+}
+
+var _ = Describe("Redisrate", func() {
+	Describe("Limit Helpers", func() {
+		It("formats and initializes PerSecond correctly", func() {
+			s := redisrate.PerSecond(10)
+			Expect(s.Rate).To(Equal(10))
+			Expect(s.Burst).To(Equal(10))
+			Expect(s.Period).To(Equal(time.Second))
+			Expect(s.String()).To(Equal("10 req/s (burst 10)"))
+			Expect(s.IsZero()).To(BeFalse())
+		})
+
+		It("formats and initializes PerMinute correctly", func() {
+			m := redisrate.PerMinute(120)
+			Expect(m.Rate).To(Equal(120))
+			Expect(m.Burst).To(Equal(120))
+			Expect(m.Period).To(Equal(time.Minute))
+			Expect(m.String()).To(Equal("120 req/m (burst 120)"))
+			Expect(m.IsZero()).To(BeFalse())
+		})
+
+		It("formats and initializes PerHour correctly", func() {
+			h := redisrate.PerHour(3600)
+			Expect(h.Rate).To(Equal(3600))
+			Expect(h.Burst).To(Equal(3600))
+			Expect(h.Period).To(Equal(time.Hour))
+			Expect(h.String()).To(Equal("3600 req/h (burst 3600)"))
+			Expect(h.IsZero()).To(BeFalse())
+		})
+
+		It("formats custom limits and detects IsZero", func() {
+			custom := redisrate.Limit{Rate: 5, Burst: 15, Period: 2 * time.Second}
+			Expect(custom.String()).To(Equal("5 req/2s (burst 15)"))
+
+			empty := redisrate.Limit{}
+			Expect(empty.IsZero()).To(BeTrue())
+		})
+	})
+
+	Describe("Limiter Constructors & Nil Handling", func() {
+		It("creates limiter instances via NewLimiter and NewLimiterFromClient", func() {
+			client := getTestClient()
+			if client == nil {
+				Skip("skipping test: no live Valkey/Redis instance accessible on 127.0.0.1:6379 or 6378")
+			}
+			defer client.Close()
+
+			adapter := valkeycompat.NewAdapter(client)
+			l1 := redisrate.NewLimiter(adapter)
+			Expect(l1).NotTo(BeNil())
+
+			l2 := redisrate.NewLimiterFromClient(client)
+			Expect(l2).NotTo(BeNil())
+
+			l3 := redisrate.NewLimiter(nil)
+			Expect(l3).NotTo(BeNil())
+		})
+
+		It("returns appropriate errors when client is nil", func() {
+			l := redisrate.NewLimiter(nil)
+			ctx := context.Background()
+			limit := redisrate.PerSecond(10)
+
+			_, err := l.Allow(ctx, "k", limit)
+			Expect(err).To(HaveOccurred())
+
+			_, err = l.AllowN(ctx, "k", limit, 1)
+			Expect(err).To(HaveOccurred())
+
+			_, err = l.AllowAtMost(ctx, "k", limit, 1)
+			Expect(err).To(HaveOccurred())
+
+			err = l.Reset(ctx, "k")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Live Valkey Rate Limiting Operations", func() {
+		var (
+			client  valkey.Client
+			limiter *redisrate.Limiter
+			ctx     context.Context
+			testID  string
+		)
+
+		BeforeEach(func() {
+			client = getTestClient()
+			if client == nil {
+				Skip("skipping test: no live Valkey/Redis instance accessible on 127.0.0.1:6379 or 6378")
+			}
+			limiter = redisrate.NewLimiter(valkeycompat.NewAdapter(client))
+			ctx = context.Background()
+			testID = fmt.Sprintf("ginkgo_rate_%d", time.Now().UnixNano())
+		})
+
+		AfterEach(func() {
+			if client != nil {
+				_ = limiter.Reset(ctx, testID)
+				client.Close()
+			}
+		})
+
+		It("executes Allow and Reset correctly", func() {
+			limit := redisrate.PerSecond(10)
+
+			// 1. First request
+			res, err := limiter.Allow(ctx, testID, limit)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(1))
+			Expect(res.Remaining).To(Equal(9))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 100*time.Millisecond, 30*time.Millisecond))
+
+			// 2. Reset and request again
+			err = limiter.Reset(ctx, testID)
+			Expect(err).NotTo(HaveOccurred())
+
+			res, err = limiter.Allow(ctx, testID, limit)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(1))
+			Expect(res.Remaining).To(Equal(9))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 100*time.Millisecond, 30*time.Millisecond))
+
+			// 3. AllowN with 2 tokens
+			res, err = limiter.AllowN(ctx, testID, limit, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(2))
+			Expect(res.Remaining).To(Equal(7))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 300*time.Millisecond, 40*time.Millisecond))
+
+			// 4. AllowN with remaining 7 tokens
+			res, err = limiter.AllowN(ctx, testID, limit, 7)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(7))
+			Expect(res.Remaining).To(Equal(0))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 999*time.Millisecond, 60*time.Millisecond))
+
+			// 5. AllowN with 1000 tokens (exceeded)
+			res, err = limiter.AllowN(ctx, testID, limit, 1000)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(0))
+			Expect(res.RetryAfter).To(BeNumerically("~", 99*time.Second, 2*time.Second))
+			Expect(res.ResetAfter).To(BeNumerically("~", 999*time.Millisecond, 60*time.Millisecond))
+		})
+
+		It("peeks without consumption when increment is zero in AllowN", func() {
+			limit := redisrate.PerSecond(10)
+
+			// Non-existent key
+			res, err := limiter.AllowN(ctx, testID, limit, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(10))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(Equal(time.Duration(0)))
+
+			// Consume 1 token
+			res, err = limiter.Allow(ctx, testID, limit)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(1))
+			Expect(res.Remaining).To(Equal(9))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 100*time.Millisecond, 30*time.Millisecond))
+
+			// Peek again
+			res, err = limiter.AllowN(ctx, testID, limit, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(9))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 100*time.Millisecond, 30*time.Millisecond))
+		})
+
+		It("calculates RetryAfter accurately under high-frequency rates", func() {
+			limit := redisrate.Limit{
+				Rate:   1,
+				Period: time.Millisecond,
+				Burst:  1,
+			}
+
+			for i := 0; i < 100; i++ {
+				res, err := limiter.Allow(ctx, testID, limit)
+				Expect(err).NotTo(HaveOccurred())
+
+				if res.Allowed > 0 {
+					continue
+				}
+
+				Expect(int64(res.RetryAfter)).To(BeNumerically("<=", int64(2*time.Millisecond)))
+			}
+		})
+
+		It("grants partial capacity when calling AllowAtMost", func() {
+			limit := redisrate.PerSecond(10)
+
+			// 1. Consume 1 token
+			res, err := limiter.Allow(ctx, testID, limit)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(1))
+			Expect(res.Remaining).To(Equal(9))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 100*time.Millisecond, 30*time.Millisecond))
+
+			// 2. Consume 2 tokens via AllowAtMost
+			res, err = limiter.AllowAtMost(ctx, testID, limit, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(2))
+			Expect(res.Remaining).To(Equal(7))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 300*time.Millisecond, 40*time.Millisecond))
+
+			// 3. Peek with AllowN(0)
+			res, err = limiter.AllowN(ctx, testID, limit, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(7))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 300*time.Millisecond, 40*time.Millisecond))
+
+			// 4. Request 10 with 7 remaining -> grants 7!
+			res, err = limiter.AllowAtMost(ctx, testID, limit, 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(7))
+			Expect(res.Remaining).To(Equal(0))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 999*time.Millisecond, 60*time.Millisecond))
+
+			// 5. Peek with AllowN(0)
+			res, err = limiter.AllowN(ctx, testID, limit, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(0))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 999*time.Millisecond, 60*time.Millisecond))
+
+			// 6. Request 1000 with 0 remaining via AllowAtMost -> grants 0, RetryAfter ~99ms
+			res, err = limiter.AllowAtMost(ctx, testID, limit, 1000)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(0))
+			Expect(res.RetryAfter).To(BeNumerically("~", 99*time.Millisecond, 30*time.Millisecond))
+			Expect(res.ResetAfter).To(BeNumerically("~", 999*time.Millisecond, 60*time.Millisecond))
+
+			// 7. Request 1000 with 0 remaining via AllowN -> rejected, RetryAfter ~99s
+			res, err = limiter.AllowN(ctx, testID, limit, 1000)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(0))
+			Expect(res.RetryAfter).To(BeNumerically("~", 99*time.Second, 2*time.Second))
+			Expect(res.ResetAfter).To(BeNumerically("~", 999*time.Millisecond, 60*time.Millisecond))
+		})
+
+		It("peeks without consumption when increment is zero in AllowAtMost", func() {
+			limit := redisrate.PerSecond(10)
+
+			// Non-existent key
+			res, err := limiter.AllowAtMost(ctx, testID, limit, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(10))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(Equal(time.Duration(0)))
+
+			// Consume 1 token
+			res, err = limiter.Allow(ctx, testID, limit)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(1))
+			Expect(res.Remaining).To(Equal(9))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 100*time.Millisecond, 30*time.Millisecond))
+
+			// Peek again
+			res, err = limiter.AllowAtMost(ctx, testID, limit, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Allowed).To(Equal(0))
+			Expect(res.Remaining).To(Equal(9))
+			Expect(res.RetryAfter).To(Equal(time.Duration(-1)))
+			Expect(res.ResetAfter).To(BeNumerically("~", 100*time.Millisecond, 30*time.Millisecond))
+		})
+	})
+})
+
+func BenchmarkAllow(b *testing.B) {
+	client, err := valkey.NewClient(valkey.ClientOption{InitAddress: []string{"127.0.0.1:6378"}})
+	if err != nil {
+		b.Skipf("cannot connect to 127.0.0.1:6378: %v", err)
+	}
+	defer client.Close()
+
+	l := redisrate.NewLimiterFromClient(client)
+	ctx := context.Background()
+	limit := redisrate.PerSecond(1e6)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		res, err := l.Allow(ctx, "bench_allow", limit)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if res.Allowed == 0 {
+			b.Fatal("rate limit exceeded during benchmark")
+		}
+	}
+}
+
+func BenchmarkAllowAtMost(b *testing.B) {
+	client, err := valkey.NewClient(valkey.ClientOption{InitAddress: []string{"127.0.0.1:6378"}})
+	if err != nil {
+		b.Skipf("cannot connect to 127.0.0.1:6378: %v", err)
+	}
+	defer client.Close()
+
+	l := redisrate.NewLimiterFromClient(client)
+	ctx := context.Background()
+	limit := redisrate.PerSecond(1e6)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		res, err := l.AllowAtMost(ctx, "bench_atmost", limit, 1)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if res.Allowed == 0 {
+			b.Fatal("rate limit exceeded during benchmark")
+		}
+	}
+}

--- a/valkeylimiter/limit.go
+++ b/valkeylimiter/limit.go
@@ -2,14 +2,58 @@ package valkeylimiter
 
 import "time"
 
+// Algorithm specifies the rate limiting algorithm to use.
+type Algorithm int
+
+const (
+	// AlgorithmGCRA selects the Generic Cell Rate Algorithm (leaky bucket). Default.
+	AlgorithmGCRA Algorithm = iota
+	// AlgorithmFixedWindow selects the legacy Fixed Window counter algorithm.
+	AlgorithmFixedWindow
+)
+
 type RateLimitOption struct {
-	limit  int64
-	window time.Duration
+	limit     int64
+	window    time.Duration
+	burst     int64
+	algorithm Algorithm
+	hasBurst  bool
+	hasAlg    bool
 }
 
+// WithCustomRateLimit creates a RateLimitOption with custom limit and window.
+// Burst defaults to limit.
 func WithCustomRateLimit(limit int, window time.Duration) RateLimitOption {
 	return RateLimitOption{
-		limit:  int64(limit),
-		window: window,
+		limit:    int64(limit),
+		window:   window,
+		burst:    int64(limit),
+		hasBurst: true,
+	}
+}
+
+// WithCustomRateLimitAndBurst creates a RateLimitOption with custom limit, window, and burst.
+func WithCustomRateLimitAndBurst(limit int, window time.Duration, burst int) RateLimitOption {
+	return RateLimitOption{
+		limit:    int64(limit),
+		window:   window,
+		burst:    int64(burst),
+		hasBurst: true,
+	}
+}
+
+// WithAlgorithm creates a RateLimitOption specifying the algorithm strategy.
+func WithAlgorithm(alg Algorithm) RateLimitOption {
+	return RateLimitOption{
+		algorithm: alg,
+		hasAlg:    true,
+	}
+}
+
+// WithBurst creates a RateLimitOption specifying a custom burst capacity.
+func WithBurst(burst int) RateLimitOption {
+	return RateLimitOption{
+		burst:    int64(burst),
+		hasBurst: true,
 	}
 }

--- a/valkeylimiter/limiter.go
+++ b/valkeylimiter/limiter.go
@@ -3,6 +3,7 @@ package valkeylimiter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -181,3 +182,225 @@ end
 local current = redis.call("incrby", rate_limit_key, increment_amount)
 return { current, expires_at }
 `)
+
+// GCRAResult contains the raw numeric and timing results returned by the GCRA Lua engine.
+type GCRAResult struct {
+	Allowed    int64
+	Remaining  int64
+	RetryAfter time.Duration
+	ResetAfter time.Duration
+}
+
+// DurFromSecString parses a float-in-seconds string (e.g., "-1", "0.1", "1.5") into a time.Duration.
+// A value of -1 returns time.Duration(-1), indicating no retry wait is needed.
+func DurFromSecString(s string) (time.Duration, error) {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	if f == -1 {
+		return -1, nil
+	}
+	if f < 0 {
+		return 0, nil
+	}
+	return time.Duration(f * float64(time.Second)), nil
+}
+
+// ParseGCRAResponse parses the 4-element array response from the GCRA Lua scripts.
+// The array format is:
+// [0] allowed (int64): count of allowed tokens (0 if rejected, or cost if allowed)
+// [1] remaining (int64): maximum permitted instantaneous tokens
+// [2] retry_after (string): float seconds until next request permitted ("-1" if allowed)
+// [3] reset_after (string): float seconds until full rate limit restoration
+func ParseGCRAResponse(resp valkey.ValkeyResult) (GCRAResult, error) {
+	if err := resp.Error(); err != nil {
+		return GCRAResult{}, err
+	}
+
+	arr, err := resp.ToArray()
+	if err != nil || len(arr) != 4 {
+		return GCRAResult{}, ErrInvalidResponse
+	}
+
+	allowed, err := arr[0].AsInt64()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid allowed count: %v", ErrInvalidResponse, err)
+	}
+
+	remaining, err := arr[1].AsInt64()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid remaining count: %v", ErrInvalidResponse, err)
+	}
+
+	retryStr, err := arr[2].ToString()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid retry_after: %v", ErrInvalidResponse, err)
+	}
+	retryAfter, err := DurFromSecString(retryStr)
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: failed to parse retry_after %q: %v", ErrInvalidResponse, retryStr, err)
+	}
+
+	resetStr, err := arr[3].ToString()
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: invalid reset_after: %v", ErrInvalidResponse, err)
+	}
+	resetAfter, err := DurFromSecString(resetStr)
+	if err != nil {
+		return GCRAResult{}, fmt.Errorf("%w: failed to parse reset_after %q: %v", ErrInvalidResponse, resetStr, err)
+	}
+
+	return GCRAResult{
+		Allowed:    allowed,
+		Remaining:  remaining,
+		RetryAfter: retryAfter,
+		ResetAfter: resetAfter,
+	}, nil
+}
+
+func ExecGCRAAllowN(ctx context.Context, client valkey.Client, key string, burst int64, rate int64, period time.Duration, cost int64) (GCRAResult, error) {
+	resp := gcraAllowNScript.Exec(ctx, client, []string{key}, []string{
+		strconv.FormatInt(burst, 10),
+		strconv.FormatInt(rate, 10),
+		strconv.FormatFloat(period.Seconds(), 'f', -1, 64),
+		strconv.FormatInt(cost, 10),
+	})
+	return ParseGCRAResponse(resp)
+}
+
+func ExecGCRAAllowAtMost(ctx context.Context, client valkey.Client, key string, burst int64, rate int64, period time.Duration, cost int64) (GCRAResult, error) {
+	resp := gcraAllowAtMostScript.Exec(ctx, client, []string{key}, []string{
+		strconv.FormatInt(burst, 10),
+		strconv.FormatInt(rate, 10),
+		strconv.FormatFloat(period.Seconds(), 'f', -1, 64),
+		strconv.FormatInt(cost, 10),
+	})
+	return ParseGCRAResponse(resp)
+}
+
+// gcraAllowNScript implements the atomic GCRA allowN (all-or-nothing) algorithm in Lua.
+// KEYS[1]: rate limit key
+// ARGV[1]: burst tolerance count
+// ARGV[2]: rate (number of operations per period)
+// ARGV[3]: period in seconds
+// ARGV[4]: cost (tokens requested)
+var gcraAllowNScript = valkey.NewLuaScript(`
+redis.replicate_commands()
+
+local rate_limit_key = KEYS[1]
+local burst = tonumber(ARGV[1])
+local rate = tonumber(ARGV[2])
+local period = tonumber(ARGV[3])
+local cost = tonumber(ARGV[4])
+
+local emission_interval = period / rate
+local increment = emission_interval * cost
+local burst_offset = emission_interval * burst
+
+local jan_1_2017 = 1483228800
+local now = redis.call("TIME")
+now = (now[1] - jan_1_2017) + (now[2] / 1000000)
+
+local tat = redis.call("GET", rate_limit_key)
+
+if not tat then
+  tat = now
+else
+  tat = tonumber(tat)
+end
+
+tat = math.max(tat, now)
+
+local diff = burst_offset - increment - (tat - now)
+local remaining = diff / emission_interval
+
+if remaining < 0 then
+  local reset_after = tat - now
+  local retry_after = diff * -1
+  return {
+    0,
+    0,
+    tostring(retry_after),
+    tostring(reset_after),
+  }
+end
+
+local new_tat = tat + increment
+local reset_after = new_tat - now
+if reset_after > 0 then
+  redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+end
+local retry_after = -1
+return {cost, math.floor(remaining + 1e-9), tostring(retry_after), tostring(reset_after)}
+`)
+
+// gcraAllowAtMostScript implements the atomic GCRA allowAtMost (partial grant) algorithm in Lua.
+// KEYS[1]: rate limit key
+// ARGV[1]: burst tolerance count
+// ARGV[2]: rate (number of operations per period)
+// ARGV[3]: period in seconds
+// ARGV[4]: cost (maximum tokens requested)
+var gcraAllowAtMostScript = valkey.NewLuaScript(`
+redis.replicate_commands()
+
+local rate_limit_key = KEYS[1]
+local burst = tonumber(ARGV[1])
+local rate = tonumber(ARGV[2])
+local period = tonumber(ARGV[3])
+local cost = tonumber(ARGV[4])
+
+local emission_interval = period / rate
+local burst_offset = emission_interval * burst
+
+local jan_1_2017 = 1483228800
+local now = redis.call("TIME")
+now = (now[1] - jan_1_2017) + (now[2] / 1000000)
+
+local tat = redis.call("GET", rate_limit_key)
+
+if not tat then
+  tat = now
+else
+  tat = tonumber(tat)
+end
+
+tat = math.max(tat, now)
+
+local diff = burst_offset - (tat - now)
+local remaining = diff / emission_interval
+
+if remaining < 1 then
+  local reset_after = tat - now
+  local retry_after = emission_interval - diff
+  return {
+    0,
+    0,
+    tostring(retry_after),
+    tostring(reset_after),
+  }
+end
+
+if remaining < cost then
+  cost = remaining
+  remaining = 0
+else
+  remaining = remaining - cost
+end
+
+local increment = emission_interval * cost
+local new_tat = tat + increment
+
+local reset_after = new_tat - now
+if reset_after > 0 then
+  redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+end
+
+return {
+  cost,
+  math.floor(remaining + 1e-9),
+  tostring(-1),
+  tostring(reset_after),
+}
+`)
+

--- a/valkeylimiter/limiter.go
+++ b/valkeylimiter/limiter.go
@@ -19,21 +19,27 @@ var (
 )
 
 type Result struct {
-	Allowed   bool
-	Remaining int64
-	ResetAtMs int64
+	Allowed    bool
+	Remaining  int64
+	ResetAtMs  int64
+	RetryAfter time.Duration
+	ResetAfter time.Duration
+	Granted    int64
 }
 
 type RateLimiterClient interface {
 	Check(ctx context.Context, identifier string, options ...RateLimitOption) (Result, error)
 	Allow(ctx context.Context, identifier string, options ...RateLimitOption) (Result, error)
 	AllowN(ctx context.Context, identifier string, n int64, options ...RateLimitOption) (Result, error)
+	AllowAtMost(ctx context.Context, identifier string, n int64, options ...RateLimitOption) (Result, error)
+	Reset(ctx context.Context, identifier string) error
 	Limit() int
 	Close()
 }
 
 const (
 	PlaceholderPrefix = "valkeylimiter"
+	GCRAPrefix        = "rate:"
 	keyDelimOpen      = ":{"
 	keyDelimClose     = "}"
 )
@@ -50,6 +56,8 @@ type RateLimiterOption struct {
 	ClientOption  valkey.ClientOption
 	Limit         int
 	Window        time.Duration
+	Burst         int
+	Algorithm     Algorithm
 }
 
 func NewRateLimiter(option RateLimiterOption) (RateLimiterClient, error) {
@@ -59,15 +67,27 @@ func NewRateLimiter(option RateLimiterOption) (RateLimiterClient, error) {
 	if option.Limit <= 0 {
 		return nil, ErrInvalidLimit
 	}
+	if option.Burst <= 0 {
+		option.Burst = option.Limit
+	}
 	if option.KeyPrefix == "" {
-		option.KeyPrefix = PlaceholderPrefix
+		if option.Algorithm == AlgorithmFixedWindow {
+			option.KeyPrefix = PlaceholderPrefix
+		} else {
+			option.KeyPrefix = GCRAPrefix
+		}
 	}
 
 	rl := &rateLimiter{
 		defaultRateLimit: RateLimitOption{
-			limit:  int64(option.Limit),
-			window: option.Window,
+			limit:     int64(option.Limit),
+			window:    option.Window,
+			burst:     int64(option.Burst),
+			algorithm: option.Algorithm,
+			hasBurst:  true,
+			hasAlg:    true,
 		},
+		keyPrefix: option.KeyPrefix,
 	}
 
 	var err error
@@ -79,12 +99,37 @@ func NewRateLimiter(option RateLimiterOption) (RateLimiterClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	rl.keyPrefix = option.KeyPrefix
 	return rl, nil
 }
 
 func (l *rateLimiter) Limit() int {
 	return int(l.defaultRateLimit.limit)
+}
+
+func (l *rateLimiter) resolveOptions(options []RateLimitOption) (limit int64, window time.Duration, burst int64, alg Algorithm) {
+	limit = l.defaultRateLimit.limit
+	window = l.defaultRateLimit.window
+	burst = l.defaultRateLimit.burst
+	alg = l.defaultRateLimit.algorithm
+
+	for _, opt := range options {
+		if opt.limit > 0 {
+			limit = opt.limit
+		}
+		if opt.window > 0 {
+			window = opt.window
+		}
+		if opt.hasBurst && opt.burst > 0 {
+			burst = opt.burst
+		}
+		if opt.hasAlg {
+			alg = opt.algorithm
+		}
+	}
+	if burst <= 0 {
+		burst = limit
+	}
+	return
 }
 
 func (l *rateLimiter) Check(ctx context.Context, identifier string, options ...RateLimitOption) (Result, error) {
@@ -99,11 +144,87 @@ func (l *rateLimiter) AllowN(ctx context.Context, identifier string, n int64, op
 	if n < 0 {
 		return Result{}, ErrInvalidTokens
 	}
-	rl := l.defaultRateLimit
-	if len(options) > 0 {
-		rl = options[len(options)-1]
+	limit, window, burst, alg := l.resolveOptions(options)
+	if alg == AlgorithmFixedWindow {
+		return l.allowNFixedWindow(ctx, identifier, n, limit, window)
+	}
+	return l.allowNGCRA(ctx, identifier, n, limit, window, burst)
+}
+
+func (l *rateLimiter) AllowAtMost(ctx context.Context, identifier string, n int64, options ...RateLimitOption) (Result, error) {
+	if n < 0 {
+		return Result{}, ErrInvalidTokens
+	}
+	limit, window, burst, alg := l.resolveOptions(options)
+	if alg == AlgorithmFixedWindow {
+		return l.allowAtMostFixedWindow(ctx, identifier, n, limit, window)
+	}
+	return l.allowAtMostGCRA(ctx, identifier, n, limit, window, burst)
+}
+
+func (l *rateLimiter) Reset(ctx context.Context, identifier string) error {
+	bufs := rateBuffersPool.Get(0, 128)
+	defer rateBuffersPool.Put(bufs)
+
+	if l.defaultRateLimit.algorithm == AlgorithmFixedWindow {
+		offset := len(bufs.keyBuf)
+		bufs.keyBuf = append(bufs.keyBuf, l.keyPrefix...)
+		bufs.keyBuf = append(bufs.keyBuf, keyDelimOpen...)
+		bufs.keyBuf = append(bufs.keyBuf, identifier...)
+		bufs.keyBuf = append(bufs.keyBuf, keyDelimClose...)
+		key := valkey.BinaryString(bufs.keyBuf[offset:])
+
+		offset = len(bufs.keyBuf)
+		bufs.keyBuf = append(bufs.keyBuf, key...)
+		bufs.keyBuf = append(bufs.keyBuf, ":ex"...)
+		expiresAtKey := valkey.BinaryString(bufs.keyBuf[offset:])
+
+		return l.client.Do(ctx, l.client.B().Del().Key(key, expiresAtKey).Build()).Error()
 	}
 
+	offset := len(bufs.keyBuf)
+	bufs.keyBuf = append(bufs.keyBuf, l.keyPrefix...)
+	bufs.keyBuf = append(bufs.keyBuf, identifier...)
+	key := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	return l.client.Do(ctx, l.client.B().Del().Key(key).Build()).Error()
+}
+
+func (l *rateLimiter) allowAtMostFixedWindow(ctx context.Context, identifier string, n int64, limit int64, window time.Duration) (Result, error) {
+	checkRes, err := l.allowNFixedWindow(ctx, identifier, 0, limit, window)
+	if err != nil {
+		return Result{}, err
+	}
+	if checkRes.Remaining <= 0 {
+		return Result{
+			Allowed:    false,
+			Remaining:  0,
+			ResetAtMs:  checkRes.ResetAtMs,
+			RetryAfter: checkRes.RetryAfter,
+			ResetAfter: checkRes.ResetAfter,
+			Granted:    0,
+		}, nil
+	}
+	granted := min(n, checkRes.Remaining)
+	if granted <= 0 {
+		return Result{
+			Allowed:    false,
+			Remaining:  checkRes.Remaining,
+			ResetAtMs:  checkRes.ResetAtMs,
+			RetryAfter: checkRes.RetryAfter,
+			ResetAfter: checkRes.ResetAfter,
+			Granted:    0,
+		}, nil
+	}
+	res, err := l.allowNFixedWindow(ctx, identifier, granted, limit, window)
+	if err != nil {
+		return Result{}, err
+	}
+	res.Granted = granted
+	return res, nil
+}
+
+func (l *rateLimiter) allowNFixedWindow(ctx context.Context, identifier string, n int64, limit int64, window time.Duration) (Result, error) {
 	bufs := rateBuffersPool.Get(0, 128)
 	defer rateBuffersPool.Put(bufs)
 
@@ -126,7 +247,7 @@ func (l *rateLimiter) AllowN(ctx context.Context, identifier string, n int64, op
 	arg1 := valkey.BinaryString(bufs.keyBuf[offset:])
 
 	offset = len(bufs.keyBuf)
-	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, now.Add(rl.window).UnixMilli(), 10)
+	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, now.Add(window).UnixMilli(), 10)
 	arg2 := valkey.BinaryString(bufs.keyBuf[offset:])
 
 	offset = len(bufs.keyBuf)
@@ -153,13 +274,139 @@ func (l *rateLimiter) AllowN(ctx context.Context, identifier string, n int64, op
 		return Result{}, ErrInvalidResponse
 	}
 
-	remaining := max(rl.limit-current, 0)
-	allowed := current <= rl.limit && (n > 0 || current < rl.limit)
+	remaining := max(limit-current, 0)
+	allowed := current <= limit && (n > 0 || current < limit)
+
+	var retryAfter time.Duration
+	if !allowed {
+		diffMs := resetAt - now.UnixMilli()
+		if diffMs > 0 {
+			retryAfter = time.Duration(diffMs) * time.Millisecond
+		}
+	} else {
+		retryAfter = -1
+	}
+
+	var resetAfter time.Duration
+	diffResetMs := resetAt - now.UnixMilli()
+	if diffResetMs > 0 {
+		resetAfter = time.Duration(diffResetMs) * time.Millisecond
+	}
+
+	granted := int64(0)
+	if allowed {
+		granted = n
+	}
 
 	return Result{
-		Allowed:   allowed,
-		Remaining: remaining,
-		ResetAtMs: resetAt,
+		Allowed:    allowed,
+		Remaining:  remaining,
+		ResetAtMs:  resetAt,
+		RetryAfter: retryAfter,
+		ResetAfter: resetAfter,
+		Granted:    granted,
+	}, nil
+}
+
+func (l *rateLimiter) allowNGCRA(ctx context.Context, identifier string, n int64, limit int64, window time.Duration, burst int64) (Result, error) {
+	bufs := rateBuffersPool.Get(0, 128)
+	defer rateBuffersPool.Put(bufs)
+
+	offset := len(bufs.keyBuf)
+	bufs.keyBuf = append(bufs.keyBuf, l.keyPrefix...)
+	bufs.keyBuf = append(bufs.keyBuf, identifier...)
+	key := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, burst, 10)
+	argBurst := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, limit, 10)
+	argRate := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendFloat(bufs.keyBuf, window.Seconds(), 'f', -1, 64)
+	argPeriod := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, n, 10)
+	argCost := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	resp := gcraAllowNScript.Exec(ctx, l.client, []string{key}, []string{argBurst, argRate, argPeriod, argCost})
+	gcraRes, err := ParseGCRAResponse(resp)
+	if err != nil {
+		return Result{}, err
+	}
+
+	allowed := gcraRes.Allowed > 0
+	if n == 0 {
+		allowed = gcraRes.Remaining > 0 && gcraRes.RetryAfter == -1
+	}
+
+	resetAtMs := int64(0)
+	if gcraRes.ResetAfter > 0 {
+		resetAtMs = time.Now().Add(gcraRes.ResetAfter).UnixMilli()
+	}
+
+	return Result{
+		Allowed:    allowed,
+		Remaining:  gcraRes.Remaining,
+		ResetAtMs:  resetAtMs,
+		RetryAfter: gcraRes.RetryAfter,
+		ResetAfter: gcraRes.ResetAfter,
+		Granted:    gcraRes.Allowed,
+	}, nil
+}
+
+func (l *rateLimiter) allowAtMostGCRA(ctx context.Context, identifier string, n int64, limit int64, window time.Duration, burst int64) (Result, error) {
+	bufs := rateBuffersPool.Get(0, 128)
+	defer rateBuffersPool.Put(bufs)
+
+	offset := len(bufs.keyBuf)
+	bufs.keyBuf = append(bufs.keyBuf, l.keyPrefix...)
+	bufs.keyBuf = append(bufs.keyBuf, identifier...)
+	key := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, burst, 10)
+	argBurst := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, limit, 10)
+	argRate := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendFloat(bufs.keyBuf, window.Seconds(), 'f', -1, 64)
+	argPeriod := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
+	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, n, 10)
+	argCost := valkey.BinaryString(bufs.keyBuf[offset:])
+
+	resp := gcraAllowAtMostScript.Exec(ctx, l.client, []string{key}, []string{argBurst, argRate, argPeriod, argCost})
+	gcraRes, err := ParseGCRAResponse(resp)
+	if err != nil {
+		return Result{}, err
+	}
+
+	allowed := gcraRes.Allowed > 0
+	if n == 0 {
+		allowed = gcraRes.Remaining > 0 && gcraRes.RetryAfter == -1
+	}
+
+	resetAtMs := int64(0)
+	if gcraRes.ResetAfter > 0 {
+		resetAtMs = time.Now().Add(gcraRes.ResetAfter).UnixMilli()
+	}
+
+	return Result{
+		Allowed:    allowed,
+		Remaining:  gcraRes.Remaining,
+		ResetAtMs:  resetAtMs,
+		RetryAfter: gcraRes.RetryAfter,
+		ResetAfter: gcraRes.ResetAfter,
+		Granted:    gcraRes.Allowed,
 	}, nil
 }
 

--- a/valkeylimiter/limiter_test.go
+++ b/valkeylimiter/limiter_test.go
@@ -457,3 +457,332 @@ func BenchmarkAllowN(b *testing.B) {
 		}
 	}
 }
+
+func TestDurFromSecString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:  "negative one represents no retry",
+			input: "-1",
+			want:  -1,
+		},
+		{
+			name:  "zero seconds",
+			input: "0",
+			want:  0,
+		},
+		{
+			name:  "fractional seconds 100ms",
+			input: "0.1",
+			want:  100 * time.Millisecond,
+		},
+		{
+			name:  "one second",
+			input: "1.0",
+			want:  time.Second,
+		},
+		{
+			name:  "multi second float",
+			input: "2.5",
+			want:  2500 * time.Millisecond,
+		},
+		{
+			name:  "negative number other than -1",
+			input: "-0.5",
+			want:  0,
+		},
+		{
+			name:    "invalid float string",
+			input:   "not-a-number",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := valkeylimiter.DurFromSecString(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("DurFromSecString(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("DurFromSecString(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGCRAResponse(t *testing.T) {
+	t.Run("success allowed", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+		))
+
+		got, err := valkeylimiter.ParseGCRAResponse(resp)
+		if err != nil {
+			t.Fatalf("ParseGCRAResponse() unexpected error: %v", err)
+		}
+
+		want := valkeylimiter.GCRAResult{
+			Allowed:    1,
+			Remaining:  9,
+			RetryAfter: -1,
+			ResetAfter: 100 * time.Millisecond,
+		}
+		if got != want {
+			t.Fatalf("ParseGCRAResponse() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("success rejected", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(0),
+			mock.ValkeyInt64(0),
+			mock.ValkeyString("0.5"),
+			mock.ValkeyString("1.0"),
+		))
+
+		got, err := valkeylimiter.ParseGCRAResponse(resp)
+		if err != nil {
+			t.Fatalf("ParseGCRAResponse() unexpected error: %v", err)
+		}
+
+		want := valkeylimiter.GCRAResult{
+			Allowed:    0,
+			Remaining:  0,
+			RetryAfter: 500 * time.Millisecond,
+			ResetAfter: time.Second,
+		}
+		if got != want {
+			t.Fatalf("ParseGCRAResponse() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("valkey error", func(t *testing.T) {
+		resp := mock.ErrorResult(errors.New("valkey cluster error"))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if err == nil {
+			t.Fatal("ParseGCRAResponse() expected error, got nil")
+		}
+	})
+
+	t.Run("invalid non-array response", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyString("unexpected string"))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid array length less than 4", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid array length greater than 4", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+			mock.ValkeyString("extra"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid first element (not int64 or int string)", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyString("not-an-int"),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid second element (not int64 or int string)", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyString("not-an-int"),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("0.1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid retry_after float string", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("invalid-float"),
+			mock.ValkeyString("0.1"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+
+	t.Run("invalid reset_after float string", func(t *testing.T) {
+		resp := mock.Result(mock.ValkeyArray(
+			mock.ValkeyInt64(1),
+			mock.ValkeyInt64(9),
+			mock.ValkeyString("-1"),
+			mock.ValkeyString("invalid-float"),
+		))
+		_, err := valkeylimiter.ParseGCRAResponse(resp)
+		if !errors.Is(err, valkeylimiter.ErrInvalidResponse) {
+			t.Fatalf("ParseGCRAResponse() error = %v, want ErrInvalidResponse", err)
+		}
+	})
+}
+
+func TestExecGCRAAllowN_Mock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(2),
+		mock.ValkeyInt64(8),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.2"),
+	))).Times(1)
+
+	got, err := valkeylimiter.ExecGCRAAllowN(context.Background(), client, "rate:{user:1}", 10, 10, time.Second, 2)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN() unexpected error: %v", err)
+	}
+
+	want := valkeylimiter.GCRAResult{
+		Allowed:    2,
+		Remaining:  8,
+		RetryAfter: -1,
+		ResetAfter: 200 * time.Millisecond,
+	}
+	if got != want {
+		t.Fatalf("ExecGCRAAllowN() = %+v, want %+v", got, want)
+	}
+}
+
+func TestExecGCRAAllowAtMost_Mock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(4),
+		mock.ValkeyInt64(0),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.6"),
+	))).Times(1)
+
+	got, err := valkeylimiter.ExecGCRAAllowAtMost(context.Background(), client, "rate:{user:2}", 10, 10, time.Second, 5)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowAtMost() unexpected error: %v", err)
+	}
+
+	want := valkeylimiter.GCRAResult{
+		Allowed:    4,
+		Remaining:  0,
+		RetryAfter: -1,
+		ResetAfter: 600 * time.Millisecond,
+	}
+	if got != want {
+		t.Fatalf("ExecGCRAAllowAtMost() = %+v, want %+v", got, want)
+	}
+}
+
+func TestGCRA_LiveServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live server test in short mode")
+	}
+
+	client, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress: []string{"127.0.0.1:6378"},
+	})
+	if err != nil {
+		t.Skipf("cannot connect to 127.0.0.1:6378: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	testKey := fmt.Sprintf("test:gcra:live:%d", time.Now().UnixNano())
+
+	// Clean up key after test
+	defer func() {
+		_ = client.Do(ctx, client.B().Del().Key(testKey).Build()).Error()
+	}()
+
+	// Test AllowN: Limit 10 req / 1 sec, burst 10
+	// 1. Initial request for 1 token: should succeed, allowed = 1, remaining = 9
+	res1, err := valkeylimiter.ExecGCRAAllowN(ctx, client, testKey, 10, 10, time.Second, 1)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN 1st call error: %v", err)
+	}
+	if res1.Allowed != 1 || res1.Remaining != 9 || res1.RetryAfter != -1 {
+		t.Fatalf("ExecGCRAAllowN 1st call unexpected result: %+v", res1)
+	}
+
+	// 2. Request for 2 tokens: should succeed, allowed = 2, remaining = 7
+	res2, err := valkeylimiter.ExecGCRAAllowN(ctx, client, testKey, 10, 10, time.Second, 2)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN 2nd call error: %v", err)
+	}
+	if res2.Allowed != 2 || res2.Remaining != 7 || res2.RetryAfter != -1 {
+		t.Fatalf("ExecGCRAAllowN 2nd call unexpected result: %+v", res2)
+	}
+
+	// 3. Request exceeding remaining tokens with AllowN (cost 100): should be rejected all-or-nothing
+	res3, err := valkeylimiter.ExecGCRAAllowN(ctx, client, testKey, 10, 10, time.Second, 100)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowN 3rd call error: %v", err)
+	}
+	if res3.Allowed != 0 || res3.Remaining != 0 || res3.RetryAfter <= 0 {
+		t.Fatalf("ExecGCRAAllowN 3rd call should be rejected: %+v", res3)
+	}
+
+	// 4. Test AllowAtMost with 7 remaining, asking for 10: should grant 7
+	res4, err := valkeylimiter.ExecGCRAAllowAtMost(ctx, client, testKey, 10, 10, time.Second, 10)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowAtMost error: %v", err)
+	}
+	if res4.Allowed != 7 || res4.Remaining != 0 || res4.RetryAfter != -1 {
+		t.Fatalf("ExecGCRAAllowAtMost unexpected result: %+v", res4)
+	}
+
+	// 5. Test AllowAtMost when exhausted: should be rejected
+	res5, err := valkeylimiter.ExecGCRAAllowAtMost(ctx, client, testKey, 10, 10, time.Second, 1)
+	if err != nil {
+		t.Fatalf("ExecGCRAAllowAtMost exhausted error: %v", err)
+	}
+	if res5.Allowed != 0 || res5.Remaining != 0 || res5.RetryAfter <= 0 {
+		t.Fatalf("ExecGCRAAllowAtMost exhausted should be rejected: %+v", res5)
+	}
+}
+

--- a/valkeylimiter/limiter_test.go
+++ b/valkeylimiter/limiter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -233,8 +234,9 @@ func TestRateLimiter_AllowN(t *testing.T) {
 				ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
 					return client, nil
 				},
-				Limit:  10,
-				Window: time.Second,
+				Limit:     10,
+				Window:    time.Second,
+				Algorithm: valkeylimiter.AlgorithmFixedWindow,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -254,7 +256,7 @@ func TestRateLimiter_AllowN(t *testing.T) {
 				return
 			}
 
-			if got != tt.wantResult {
+			if got.Allowed != tt.wantResult.Allowed || got.Remaining != tt.wantResult.Remaining || got.ResetAtMs != tt.wantResult.ResetAtMs {
 				t.Fatalf("AllowN() = %+v, want %+v", got, tt.wantResult)
 			}
 		})
@@ -278,8 +280,9 @@ func TestRateLimiter_Check(t *testing.T) {
 		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
 			return client, nil
 		},
-		Limit:  10,
-		Window: time.Second,
+		Limit:     10,
+		Window:    time.Second,
+		Algorithm: valkeylimiter.AlgorithmFixedWindow,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -295,7 +298,7 @@ func TestRateLimiter_Check(t *testing.T) {
 		Remaining: 5,
 		ResetAtMs: resetTime,
 	}
-	if got != want {
+	if got.Allowed != want.Allowed || got.Remaining != want.Remaining || got.ResetAtMs != want.ResetAtMs {
 		t.Fatalf("Check() = %+v, want %+v", got, want)
 	}
 }
@@ -317,8 +320,9 @@ func TestRateLimiter_Allow(t *testing.T) {
 		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
 			return client, nil
 		},
-		Limit:  10,
-		Window: time.Second,
+		Limit:     10,
+		Window:    time.Second,
+		Algorithm: valkeylimiter.AlgorithmFixedWindow,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -334,7 +338,7 @@ func TestRateLimiter_Allow(t *testing.T) {
 		Remaining: 9,
 		ResetAtMs: resetTime,
 	}
-	if got != want {
+	if got.Allowed != want.Allowed || got.Remaining != want.Remaining || got.ResetAtMs != want.ResetAtMs {
 		t.Fatalf("Allow() = %+v, want %+v", got, want)
 	}
 }
@@ -442,8 +446,9 @@ func BenchmarkAllowN(b *testing.B) {
 		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
 			return client, nil
 		},
-		Limit:  1000,
-		Window: time.Second,
+		Limit:     1000,
+		Window:    time.Second,
+		Algorithm: valkeylimiter.AlgorithmFixedWindow,
 	})
 	if err != nil {
 		b.Fatal(err)
@@ -785,4 +790,513 @@ func TestGCRA_LiveServer(t *testing.T) {
 		t.Fatalf("ExecGCRAAllowAtMost exhausted should be rejected: %+v", res5)
 	}
 }
+
+func TestRateLimiter_GCRA_DefaultAndAllow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(1),
+		mock.ValkeyInt64(9),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.1"),
+	))).Times(1)
+
+	// NewRateLimiter without specifying Algorithm defaults to GCRA
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := limiter.Allow(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("Allow() error: %v", err)
+	}
+
+	if !got.Allowed || got.Remaining != 9 || got.Granted != 1 || got.RetryAfter != -1 || got.ResetAfter != 100*time.Millisecond {
+		t.Fatalf("Allow() unexpected result: %+v", got)
+	}
+	if got.ResetAtMs <= 0 {
+		t.Fatalf("Allow() expected ResetAtMs > 0, got %d", got.ResetAtMs)
+	}
+}
+
+func TestRateLimiter_GCRA_AllowN(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(3),
+		mock.ValkeyInt64(7),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.3"),
+	))).Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:     10,
+		Window:    time.Second,
+		Burst:     10,
+		Algorithm: valkeylimiter.AlgorithmGCRA,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := limiter.AllowN(context.Background(), "user2", 3)
+	if err != nil {
+		t.Fatalf("AllowN() error: %v", err)
+	}
+
+	if !got.Allowed || got.Remaining != 7 || got.Granted != 3 || got.RetryAfter != -1 || got.ResetAfter != 300*time.Millisecond {
+		t.Fatalf("AllowN() unexpected result: %+v", got)
+	}
+}
+
+func TestRateLimiter_GCRA_AllowAtMost(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(7),
+		mock.ValkeyInt64(0),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("1.0"),
+	))).Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := limiter.AllowAtMost(context.Background(), "user3", 10)
+	if err != nil {
+		t.Fatalf("AllowAtMost() error: %v", err)
+	}
+
+	if !got.Allowed || got.Remaining != 0 || got.Granted != 7 || got.RetryAfter != -1 || got.ResetAfter != time.Second {
+		t.Fatalf("AllowAtMost() unexpected result: %+v", got)
+	}
+}
+
+func TestRateLimiter_GCRA_Check(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(0),
+		mock.ValkeyInt64(5),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.5"),
+	))).Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := limiter.Check(context.Background(), "user4")
+	if err != nil {
+		t.Fatalf("Check() error: %v", err)
+	}
+
+	if !got.Allowed || got.Remaining != 5 || got.Granted != 0 || got.RetryAfter != -1 {
+		t.Fatalf("Check() unexpected result: %+v", got)
+	}
+}
+
+func TestRateLimiter_Reset_GCRA(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyInt64(1))).Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = limiter.Reset(context.Background(), "test_id")
+	if err != nil {
+		t.Fatalf("Reset() error: %v", err)
+	}
+}
+
+func TestRateLimiter_Reset_FixedWindow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyInt64(2))).Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:     10,
+		Window:    time.Second,
+		Algorithm: valkeylimiter.AlgorithmFixedWindow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = limiter.Reset(context.Background(), "test_id")
+	if err != nil {
+		t.Fatalf("Reset() error: %v", err)
+	}
+}
+
+func TestRateLimiter_AllowAtMost_FixedWindow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := time.Now()
+	resetTime := now.Add(time.Second).UnixMilli()
+
+	client := mock.NewClient(ctrl)
+	// Check call (n=0): returns current=6 (remaining=4)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(6),
+		mock.ValkeyInt64(resetTime),
+	))).Times(1)
+	// Second call (grant=4): returns current=10 (remaining=0)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(10),
+		mock.ValkeyInt64(resetTime),
+	))).Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:     10,
+		Window:    time.Second,
+		Algorithm: valkeylimiter.AlgorithmFixedWindow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Request 10 tokens when only 4 are remaining
+	got, err := limiter.AllowAtMost(context.Background(), "test", 10)
+	if err != nil {
+		t.Fatalf("AllowAtMost() error = %v", err)
+	}
+
+	if !got.Allowed || got.Granted != 4 || got.Remaining != 0 {
+		t.Fatalf("AllowAtMost() = %+v, want Allowed=true Granted=4 Remaining=0", got)
+	}
+}
+
+func TestRateLimiter_GCRA_LiveServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live server test in short mode")
+	}
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientOption: valkey.ClientOption{
+			InitAddress: []string{"127.0.0.1:6378"},
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Skipf("cannot connect to 127.0.0.1:6378: %v", err)
+	}
+	defer limiter.Close()
+
+	ctx := context.Background()
+	testId := fmt.Sprintf("user-live-%d", time.Now().UnixNano())
+
+	defer func() {
+		_ = limiter.Reset(ctx, testId)
+	}()
+
+	// 1. Allow single token
+	res1, err := limiter.Allow(ctx, testId)
+	if err != nil {
+		t.Fatalf("Allow() error: %v", err)
+	}
+	if !res1.Allowed || res1.Remaining != 9 || res1.Granted != 1 {
+		t.Fatalf("Allow() unexpected: %+v", res1)
+	}
+
+	// 2. AllowN 2 tokens
+	res2, err := limiter.AllowN(ctx, testId, 2)
+	if err != nil {
+		t.Fatalf("AllowN() error: %v", err)
+	}
+	if !res2.Allowed || res2.Remaining != 7 || res2.Granted != 2 {
+		t.Fatalf("AllowN() unexpected: %+v", res2)
+	}
+
+	// 3. AllowAtMost requesting 10 with 7 remaining -> should grant 7
+	res3, err := limiter.AllowAtMost(ctx, testId, 10)
+	if err != nil {
+		t.Fatalf("AllowAtMost() error: %v", err)
+	}
+	if !res3.Allowed || res3.Remaining != 0 || res3.Granted != 7 {
+		t.Fatalf("AllowAtMost() unexpected: %+v", res3)
+	}
+
+	// 4. Next call should be rejected
+	res4, err := limiter.Allow(ctx, testId)
+	if err != nil {
+		t.Fatalf("Allow() error: %v", err)
+	}
+	if res4.Allowed || res4.Remaining != 0 || res4.RetryAfter <= 0 {
+		t.Fatalf("Allow() should be rejected: %+v", res4)
+	}
+
+	// 5. Reset the key
+	err = limiter.Reset(ctx, testId)
+	if err != nil {
+		t.Fatalf("Reset() error: %v", err)
+	}
+
+	// 6. Request after reset should succeed with full capacity
+	res5, err := limiter.Allow(ctx, testId)
+	if err != nil {
+		t.Fatalf("Allow() after reset error: %v", err)
+	}
+	if !res5.Allowed || res5.Remaining != 9 || res5.Granted != 1 {
+		t.Fatalf("Allow() after reset unexpected: %+v", res5)
+	}
+}
+
+func BenchmarkAllowN_GCRA(b *testing.B) {
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(1),
+		mock.ValkeyInt64(999),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.001"),
+	))).Times(b.N)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:     1000,
+		Window:    time.Second,
+		Algorithm: valkeylimiter.AlgorithmGCRA,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := limiter.AllowN(context.Background(), "test", 1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestRateLimiter_GCRA_Concurrency_Atomicity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrency test in short mode")
+	}
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientOption: valkey.ClientOption{
+			InitAddress: []string{"127.0.0.1:6378"},
+		},
+		Limit:  10,
+		Window: 10 * time.Second,
+		Burst:  10,
+	})
+	if err != nil {
+		t.Skipf("cannot connect to 127.0.0.1:6378: %v", err)
+	}
+	defer limiter.Close()
+
+	ctx := context.Background()
+	testId := fmt.Sprintf("concurrent-test-%d", time.Now().UnixNano())
+	defer func() {
+		_ = limiter.Reset(ctx, testId)
+	}()
+
+	const totalWorkers = 50
+	var allowedCount int64
+	var rejectedCount int64
+
+	startBarrier := make(chan struct{})
+	doneCh := make(chan struct{}, totalWorkers)
+
+	for i := 0; i < totalWorkers; i++ {
+		go func() {
+			<-startBarrier
+			res, err := limiter.Allow(ctx, testId)
+			if err == nil {
+				if res.Allowed {
+					atomic.AddInt64(&allowedCount, 1)
+				} else {
+					atomic.AddInt64(&rejectedCount, 1)
+				}
+			}
+			doneCh <- struct{}{}
+		}()
+	}
+
+	close(startBarrier)
+	for i := 0; i < totalWorkers; i++ {
+		<-doneCh
+	}
+
+	if allowedCount != 10 {
+		t.Fatalf("Concurrency atomicity violated: allowed %d, want exactly 10", allowedCount)
+	}
+	if rejectedCount != 40 {
+		t.Fatalf("Concurrency atomicity violated: rejected %d, want exactly 40", rejectedCount)
+	}
+}
+
+func TestRateLimiter_OptionOverrides(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	// Expect GCRA script with custom rate 20, burst 30, window 2s
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(1),
+		mock.ValkeyInt64(29),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.1"),
+	))).Times(1)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opt := valkeylimiter.WithCustomRateLimitAndBurst(20, 2*time.Second, 30)
+	got, err := limiter.Allow(context.Background(), "user-custom", opt)
+	if err != nil {
+		t.Fatalf("Allow with custom options error: %v", err)
+	}
+	if !got.Allowed || got.Remaining != 29 {
+		t.Fatalf("Allow with custom options unexpected: %+v", got)
+	}
+
+	// Expect GCRA script with custom burst 50 (rate remains default 10, window 1s)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.Result(mock.ValkeyArray(
+		mock.ValkeyInt64(1),
+		mock.ValkeyInt64(49),
+		mock.ValkeyString("-1"),
+		mock.ValkeyString("0.1"),
+	))).Times(1)
+
+	gotBurst, err := limiter.Allow(context.Background(), "user-burst", valkeylimiter.WithBurst(50))
+	if err != nil {
+		t.Fatalf("Allow with WithBurst error: %v", err)
+	}
+	if !gotBurst.Allowed || gotBurst.Remaining != 49 {
+		t.Fatalf("Allow with WithBurst unexpected: %+v", gotBurst)
+	}
+}
+
+func TestRateLimiter_AllowAtMost_ValidationErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Negative tokens
+	_, err = limiter.AllowAtMost(context.Background(), "user-neg", -5)
+	if !errors.Is(err, valkeylimiter.ErrInvalidTokens) {
+		t.Fatalf("AllowAtMost with negative tokens error = %v, want ErrInvalidTokens", err)
+	}
+}
+
+func TestRateLimiter_ClientErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewClient(ctrl)
+	client.EXPECT().Do(gomock.Any(), gomock.Any()).Return(mock.ErrorResult(errors.New("connection failed"))).Times(3)
+
+	limiter, err := valkeylimiter.NewRateLimiter(valkeylimiter.RateLimiterOption{
+		ClientBuilder: func(option valkey.ClientOption) (valkey.Client, error) {
+			return client, nil
+		},
+		Limit:  10,
+		Window: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Allow error
+	_, err = limiter.Allow(context.Background(), "user-err")
+	if err == nil {
+		t.Fatal("Allow expected error, got nil")
+	}
+
+	// AllowAtMost error
+	_, err = limiter.AllowAtMost(context.Background(), "user-err", 5)
+	if err == nil {
+		t.Fatal("AllowAtMost expected error, got nil")
+	}
+
+	// Reset error
+	err = limiter.Reset(context.Background(), "user-err")
+	if err == nil {
+		t.Fatal("Reset expected error, got nil")
+	}
+}
+
+
 


### PR DESCRIPTION
### Summary of Changes

This PR introduces the `valkeycompat/redisrate` package.

Applications migrating from `go-redis` to `valkey-go` can replace their import:
```go
import redis_rate "github.com/valkey-io/valkey-go/valkeycompat/redisrate"
```
and continue using identical type signatures, constructors, and method invocations with zero changes to their existing rate-limiting business logic.

---

### Key Additions & Architecture

1. **`Limit` Struct & Helper Constructors**:
   - `Limit{Rate, Burst int; Period time.Duration}` with `String()` and `IsZero()`.
   - Period helpers: `PerSecond(rate)`, `PerMinute(rate)`, `PerHour(rate)`.
   - Automatic fallback: Defaults `Burst = Rate` if `Burst <= 0`.

2. **`Result` Struct & Field Mapping**:
   - `Limit Limit`: The limit configuration used.
   - `Allowed int`: Populated directly from `int(valkeyResult.Granted)`, representing `0` when rejected or the exact granted token count for `AllowAtMost`.
   - `Remaining int`: Maximum instantaneous tokens remaining.
   - `RetryAfter time.Duration`: Strictly `-1` (`time.Duration(-1)`) on success, or the calculated wait delay when throttled.
   - `ResetAfter time.Duration`: Time until the rate limiter bucket completely recharges to full capacity.

3. **`Limiter` Implementation & Dual Constructors**:
   - `NewLimiter(rdb valkeycompat.Cmdable) *Limiter`: Extracts the underlying client via `rdb.Client()`.
   - `NewLimiterFromClient(client valkey.Client) *Limiter`: Direct constructor for callers using raw `valkey.Client`.
   - `Allow(ctx, key, limit)`: Single-token evaluation shortcut.
   - `AllowN(ctx, key, limit, n)`: Delegates directly to `valkeylimiter.ExecGCRAAllowN`.
   - `AllowAtMost(ctx, key, limit, n)`: Delegates directly to `valkeylimiter.ExecGCRAAllowAtMost` (greedy partial grants).
   - `Reset(ctx, key)`: Atomically clears rate limit state via `DEL rate:<key>`.

4. **Single-Key Architecture & Rolling Migration Parity**:
   - Formats keys strictly as `rate:<key>` without mandatory `{}` wrapping to ensure 1:1 key compatibility with existing keys in Redis/Valkey and avoid cold-start cache misses during rollout.
   - Operating on `KEYS[1]` guarantees zero `CROSSSLOT` errors in Valkey Cluster.

---

### Verification & Test Logs

The test suite in `redisrate_test.go` is written in native **Ginkgo v2 + Gomega BDD** format, matching the `valkeycompat` convention, and ports all upstream test scenarios from `go-redis/redis_rate/v10` (including peeking with `cost = 0`, sequential consumption, exhaustion, and partial fulfillment).

#### 1. Ginkgo v2 Test Suite with Race Detector (`go test -count=1 -v -race ./redisrate`)

```text
=== RUN   TestRedisrate
Running Suite: Redisrate Suite - /usr/local/google/home/sonalijhala/Valkey-Repo/valkey-go/valkeycompat/redisrate
================================================================================================================
Random Seed: 1789136267

Will run 11 of 11 specs
•••••••••••

Ran 11 of 11 Specs in 0.134 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestRedisrate (0.14s)
PASS
ok  	github.com/valkey-io/valkey-go/valkeycompat/redisrate	1.236s
```

#### 2. Allocation Benchmarks (`go test -bench=. -benchmem ./redisrate`)

```text
goos: linux
goarch: amd64
pkg: github.com/valkey-io/valkey-go/valkeycompat/redisrate
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkAllow-24          	    3735	    293666 ns/op	    1415 B/op	      10 allocs/op
BenchmarkAllowAtMost-24    	    3334	    310241 ns/op	    1561 B/op	      10 allocs/op
PASS
ok  	github.com/valkey-io/valkey-go/valkeycompat/redisrate	3.315s
```