### PR TITLE
perf(cluster): consolidate keyless commands onto one conn on retry

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -947,6 +947,11 @@ func (c *clusterClient) rebucketRetries(retries *connretry) {
 		cmd    Completed
 	}
 	var moves []moved
+	// prev is the last conn we re-picked. Keyless commands (InitSlot) have no
+	// slot to route by, so instead of letting _pick return an arbitrary conn
+	// per command we consolidate them onto prev, keeping the retry round on
+	// fewer conns.
+	var prev conn
 	for oldConn, nr := range retries.m {
 		if len(nr.commands) == 0 {
 			continue
@@ -957,12 +962,21 @@ func (c *clusterClient) rebucketRetries(retries *connretry) {
 		for i := 0; i < n; {
 			if !isMulti(nr.commands[i]) {
 				cmd := nr.commands[i]
-				nc := c._pick(cmd.Slot(), c.toReplica(cmd))
+				var nc conn
+				if cmd.Slot() == cmds.InitSlot {
+					nc = prev
+				}
+				if nc == nil {
+					nc = c._pick(cmd.Slot(), c.toReplica(cmd))
+				}
 				if nc == nil || nc == oldConn {
 					keepIdx = append(keepIdx, nr.cIndexes[i])
 					keepCmd = append(keepCmd, cmd)
 				} else {
 					moves = append(moves, moved{nc: nc, cIndex: nr.cIndexes[i], cmd: cmd})
+				}
+				if nc != nil {
+					prev = nc
 				}
 				i++
 				continue
@@ -1001,6 +1015,7 @@ func (c *clusterClient) rebucketRetries(retries *connretry) {
 					moves = append(moves, moved{nc: nc, cIndex: nr.cIndexes[k], cmd: nr.commands[k]})
 				}
 			}
+			prev = nc // always a primary (or live oldConn), safe to reuse
 			i = j + 1
 		}
 		nr.cIndexes = keepIdx

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -12335,3 +12335,44 @@ func TestClusterRebucketRetriesCacheAskOnlyBucket(t *testing.T) {
 		t.Fatalf("ASK-only cache bucket must be left untouched, got %+v", retries.m)
 	}
 }
+
+// TestClusterRebucketRetriesKeylessConsolidates verifies that several keyless
+// commands in one bucket re-pick onto a single conn instead of fanning out
+// across the arbitrary conns _pick(InitSlot) would otherwise return.
+func TestClusterRebucketRetriesKeylessConsolidates(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+	client := newRebucketTestClient(t)
+	defer client.Close()
+
+	// Three live conns to choose from; oldConn is not among them, so the
+	// keyless commands must move. Without consolidation each could land on a
+	// different one of the three.
+	cA := &mockConn{DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} }}
+	cB := &mockConn{DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} }}
+	cC := &mockConn{DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} }}
+	client.mu.Lock()
+	client.conns = map[string]connrole{"a": {conn: cA}, "b": {conn: cB}, "c": {conn: cC}}
+	client.mu.Unlock()
+
+	oldConn := &mockConn{DoFn: func(cmd Completed) ValkeyResult { return ValkeyResult{} }}
+	retries := connretryp.Get(1, 1)
+	defer connretryp.Put(retries)
+	nr := retryp.Get(0, 3)
+	nr.cIndexes = append(nr.cIndexes, 0, 1, 2)
+	nr.commands = append(nr.commands, client.B().Ping().Build(), client.B().Ping().Build(), client.B().Ping().Build())
+	retries.m[oldConn] = nr
+
+	client.rebucketRetries(retries)
+
+	if _, still := retries.m[oldConn]; still {
+		t.Fatalf("oldConn bucket must be drained, got %+v", retries.m[oldConn])
+	}
+	if len(retries.m) != 1 {
+		t.Fatalf("keyless commands must consolidate onto one conn, got %d buckets", len(retries.m))
+	}
+	for _, bucket := range retries.m {
+		if len(bucket.commands) != 3 {
+			t.Fatalf("expected all 3 keyless commands on one conn, got %d", len(bucket.commands))
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #151, as suggested in https://github.com/valkey-io/valkey-go/pull/151#discussion_r3980931982.

In `rebucketRetries`, reuse the previously re-picked conn for keyless commands (`Slot() == InitSlot`) so they consolidate onto one conn instead of fanning out across the arbitrary conn `_pick(InitSlot)` returns per call.

- `prev` is only consumed in the per-command branch, never for a MULTI..EXEC span, so a replica `prev` can never route a keyless transaction to a replica.
- The first command has no `prev` yet and falls back to `_pick`.
- `DoMultiCache` path unchanged since cacheable commands always carry a real slot.