### PR TITLE
feat(cluster): add opt-in PreferClusterShards to use CLUSTER SHARDS before version 8

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -198,19 +198,19 @@ func clusterRefreshAutoMaxDelay(n int) time.Duration {
 }
 
 type clusterslots struct {
-	addr  string
-	reply ValkeyResult
-	ver   int
+	addr      string
+	reply     ValkeyResult
+	useShards bool
 }
 
 func (s clusterslots) parse(tls bool) map[string]group {
-	if s.ver < 8 {
+	if !s.useShards {
 		return parseSlots(s.reply.val, s.addr)
 	}
 	return parseShards(s.reply.val, s.addr, tls)
 }
 
-func getClusterSlots(c conn, timeout time.Duration) clusterslots {
+func getClusterSlots(c conn, timeout time.Duration, preferShards bool) clusterslots {
 	var ctx context.Context
 	var cancel context.CancelFunc
 	if timeout > 0 {
@@ -220,10 +220,13 @@ func getClusterSlots(c conn, timeout time.Duration) clusterslots {
 		ctx = context.Background()
 	}
 	v := c.Version()
-	if v < 8 {
-		return clusterslots{reply: c.Do(ctx, cmds.SlotCmd), addr: c.Addr(), ver: v}
+	// CLUSTER SHARDS on >= 8 always; below that only when opted in, and never
+	// below 7 where the command does not exist. See ClusterOption.PreferClusterShards.
+	useShards := v >= 8 || (preferShards && v >= 7)
+	if !useShards {
+		return clusterslots{reply: c.Do(ctx, cmds.SlotCmd), addr: c.Addr()}
 	}
-	return clusterslots{reply: c.Do(ctx, cmds.ShardsCmd), addr: c.Addr(), ver: v}
+	return clusterslots{reply: c.Do(ctx, cmds.ShardsCmd), addr: c.Addr(), useShards: true}
 }
 
 func (c *clusterClient) _refresh() (err error) {
@@ -382,6 +385,7 @@ func (c *clusterClient) clusterRefreshConns() []conn {
 
 func (c *clusterClient) refreshConns(pending []conn, batchDelay time.Duration) (result clusterslots, err error) {
 	results := make(chan clusterslots, len(pending))
+	preferShards := c.opt.ClusterOption.PreferClusterShards
 	for i := 0; i < len(pending); i++ {
 		if i&3 == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every 4 connections
 			if i > 0 && batchDelay > 0 {
@@ -389,7 +393,7 @@ func (c *clusterClient) refreshConns(pending []conn, batchDelay time.Duration) (
 			}
 			for j := i; j < i+4 && j < len(pending); j++ {
 				go func(c conn, timeout time.Duration) {
-					results <- getClusterSlots(c, timeout)
+					results <- getClusterSlots(c, timeout, preferShards)
 				}(pending[j], c.opt.ConnWriteTimeout)
 			}
 		}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -6295,6 +6295,40 @@ func TestConnectToNonAvailableCluster(t *testing.T) {
 	wg.Wait()
 }
 
+func TestGetClusterSlotsPreferShards(t *testing.T) {
+	for _, tc := range []struct {
+		version      int
+		preferShards bool
+		wantCmd      string
+		wantShards   bool
+	}{
+		{version: 8, preferShards: false, wantCmd: "CLUSTER SHARDS", wantShards: true},  // >= 8 always shards
+		{version: 7, preferShards: false, wantCmd: "CLUSTER SLOTS", wantShards: false},  // default keeps 7.x on slots
+		{version: 7, preferShards: true, wantCmd: "CLUSTER SHARDS", wantShards: true},   // opt-in enables shards on 7
+		{version: 6, preferShards: true, wantCmd: "CLUSTER SLOTS", wantShards: false},   // floor: no shards below 7
+		{version: 5, preferShards: true, wantCmd: "CLUSTER SLOTS", wantShards: false},   // RESP2 fallback stays slots
+	} {
+		t.Run(fmt.Sprintf("v%d_prefer%v", tc.version, tc.preferShards), func(t *testing.T) {
+			var got string
+			c := &mockConn{
+				VersionFn: func() int { return tc.version },
+				AddrFn:    func() string { return "127.0.0.1:0" },
+				DoFn: func(cmd Completed) ValkeyResult {
+					got = strings.Join(cmd.Commands(), " ")
+					return NewResult(slicemsg('*', []ValkeyMessage{}), nil)
+				},
+			}
+			res := getClusterSlots(c, 0, tc.preferShards)
+			if got != tc.wantCmd {
+				t.Fatalf("version %d preferShards %v: sent %q, want %q", tc.version, tc.preferShards, got, tc.wantCmd)
+			}
+			if res.useShards != tc.wantShards {
+				t.Fatalf("version %d preferShards %v: useShards %v, want %v", tc.version, tc.preferShards, res.useShards, tc.wantShards)
+			}
+		})
+	}
+}
+
 func TestClusterTopologyRefreshment(t *testing.T) {
 	defer ShouldNotLeak(SetupLeakDetection())
 

--- a/valkey.go
+++ b/valkey.go
@@ -337,6 +337,14 @@ type ClusterOption struct {
 
 	// PreferInitAddressRefresh only uses ClientOption.InitAddress nodes during cluster topology refresh.
 	PreferInitAddressRefresh bool
+
+	// PreferClusterShards uses CLUSTER SHARDS instead of CLUSTER SLOTS to refresh the cluster topology
+	// on servers with version >= 7 (by default CLUSTER SHARDS is only used on version >= 8).
+	// CLUSTER SHARDS reports the per-node "health" field, which lets the client drop nodes that are not
+	// online (e.g. LOADING during a failover) instead of routing to them.
+	// Enable this ONLY if your engine's CLUSTER SHARDS is fixed: Valkey >= 7.2.6 or Redis >= 8.0.
+	// Do NOT enable it on Redis 7.x: its CLUSTER SHARDS returns wrong topology after a failover.
+	PreferClusterShards bool
 }
 
 // StandaloneOption is the options for the standalone client.


### PR DESCRIPTION
By default the client refreshes cluster topology with `CLUSTER SHARDS` only on servers version 8 and above, and uses `CLUSTER SLOTS` below that. This was done because `CLUSTER SHARDS` had a server side bug on older versions.

The bug is fixed in Valkey `7.2.6` and Redis `8.0`, so users on those versions can now opt in to `CLUSTER SHARDS` earlier by setting PreferClusterShards. This keeps the health field from `CLUSTER SHARDS` during rolling engine upgrades, which avoids routing commands to nodes that are still loading.

The option is off by default so existing behavior does not change. It only takes effect on servers version `7` and above, so it never sends `CLUSTER SHARDS` to a server that does not support the command.