### PR TITLE
docs: fix the Receive cleanup and parse-error examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Note that `client.Receive()` doesn't unsubscribe channels automatically when it 
 ```go
 ctx, cancel := context.WithCancel(context.Background())
 
-ctx = valkey.WithOnReceiveReturnHook(context.Background(), func(err error, client valkey.CommandClient) error {
+ctx = valkey.WithOnReceiveReturnHook(ctx, func(err error, client valkey.CommandClient) error {
   if errors.Is(err, context.Canceled) {
     // Send UNSUBSCRIBE command to the connection
     return client.Do(context.Background(), client.B().Unsubscribe().Channel("news").Build()).Error()
@@ -641,7 +641,7 @@ If an incorrect parser function is chosen, an errParse will be returned. Here's 
 // Attempt to parse the response. If a parsing error occurs, check if the error is a parse error and handle it.
 // Normally, you should fix the code by choosing the correct parser function.
 // For instance, use ToString() if the expected response is a string, or ToArray() if the expected response is an array as follows:
-if err := client.Do(ctx, client.B().Get().Key("k").Build()).ToArray(); IsParseErr(err) {
+if _, err := client.Do(ctx, client.B().Get().Key("k").Build()).ToArray(); valkey.IsParseErr(err) {
     fmt.Println("Parsing error:", err)
 }
 ```


### PR DESCRIPTION
The return-hook test and the README disagree about which context `WithOnReceiveReturnHook` should wrap. The test passes the cancellable `ctx`; the sample replaces it with `context.Background()`.

`WithOnReceiveReturnHook` only calls `context.WithValue`, so `Receive` gets the wrapped context's `Done()`. With `context.Background()`, that's nil, and `Receive` takes the unconditional channel loop instead of the select with `case <-ctx.Done()`. Calling `cancel()` in the message handler therefore does nothing that `Receive` can see. It never returns, so the UNSUBSCRIBE hook never fires.

Anyone copying that sample gets a silent hang and is left blaming thier own cleanup code.

The `IsParseErr` sample fails sooner. `ToArray()` returns two values, and the exported function needs its `valkey.` qualifier. Copied into an external package against `github.com/valkey-io/valkey-go v1.0.77`, it fails twice:

    assignment mismatch: 1 variable but client.Do(ctx, client.B().Get().Key("k").Build()).ToArray returns 2 values
    undefined: IsParseErr

That stops readers before they've learnt anything about parse errors.

The cleanup sample arrived alongside the correct test in a83f17a. The parse-error line has been there since June 2024, and CI doesnt compile README snippets.
